### PR TITLE
fix: resolve docker build failure and clean up project root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 RUN go test -v ./...
 
 # Compile the binary statically
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o uplarr .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o uplarr ./cmd/uplarr
 
 # Stage 2: Final minimal image
 FROM alpine:3.23


### PR DESCRIPTION
- Fix: Update Dockerfile to build from ./cmd/uplarr instead of root.
- Cleanup: Remove test artifacts (coverage files, etc.) from project root.
- Verification: Audit of all code hardening findings confirmed complete.