### PR TITLE
fix: add cmd/uplarr to git and fix .gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@
 *.out
 *.prof
 coverage/
-coverage
-c
+/coverage
+/c
 coverage.html
 coverage.txt
 
@@ -22,12 +22,12 @@ coverage.txt
 
 # Uplarr specific
 test_data/
-uplarr
+/uplarr
 .qodo/
 .DS_Store
 .env
 
 # Test coverage artifacts
-api
-api_cov
-queue
+/api
+/api_cov
+/queue

--- a/cmd/uplarr/main.go
+++ b/cmd/uplarr/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+
+	"uplarr/internal/api"
+	"uplarr/internal/logger"
+	"uplarr/internal/models"
+	"uplarr/internal/queue"
+)
+
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
+func getEnvInt(key string, fallback int) int {
+	if value, ok := os.LookupEnv(key); ok {
+		i, err := strconv.Atoi(value)
+		if err != nil {
+			return fallback
+		}
+		return i
+	}
+	return fallback
+}
+
+var (
+	httpListenAndServe = http.ListenAndServe
+	apiSetupApp        = api.SetupApp
+	osExit             = os.Exit
+)
+
+func Run() error {
+	config := models.Config{
+		LocalDir: getEnv("LOCAL_DIR", "./test_data"),
+		WebPort:  getEnv("WEB_PORT", "8080"),
+	}
+
+	qm := queue.NewQueueManager(config.LocalDir)
+
+	mux, err := apiSetupApp(config, qm)
+	if err != nil {
+		return fmt.Errorf("setup failed: %v", err)
+	}
+
+	logger.Info(fmt.Sprintf("Server starting on port: %s", config.WebPort))
+	return httpListenAndServe(":"+config.WebPort, mux)
+}
+
+func main() {
+	if err := Run(); err != nil {
+		logger.Error(fmt.Sprintf("Application failed: %v", err))
+		osExit(1)
+	}
+}

--- a/cmd/uplarr/main_test.go
+++ b/cmd/uplarr/main_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"uplarr/internal/models"
+	"uplarr/internal/queue"
+)
+
+func TestGetEnv(t *testing.T) {
+	os.Setenv("TEST_VAR", "value")
+	defer os.Unsetenv("TEST_VAR")
+	if getEnv("TEST_VAR", "fallback") != "value" { t.Error("Expected value") }
+	if getEnv("MISSING_VAR", "fallback") != "fallback" { t.Error("Expected fallback") }
+}
+
+func TestGetEnvInt(t *testing.T) {
+	os.Setenv("TEST_INT", "123")
+	defer os.Unsetenv("TEST_INT")
+	if getEnvInt("TEST_INT", 0) != 123 { t.Error("Expected 123") }
+	if getEnvInt("MISSING_INT", 456) != 456 { t.Error("Expected 456") }
+	os.Setenv("INVALID_INT", "abc")
+	if getEnvInt("INVALID_INT", 789) != 789 { t.Error("Expected fallback for invalid int") }
+}
+
+func TestRunSuccess(t *testing.T) {
+	oldSetup := apiSetupApp
+	oldListen := httpListenAndServe
+	defer func() {
+		apiSetupApp = oldSetup
+		httpListenAndServe = oldListen
+	}()
+
+	apiSetupApp = func(config models.Config, qm *queue.QueueManager) (*http.ServeMux, error) {
+		return http.NewServeMux(), nil
+	}
+	httpListenAndServe = func(addr string, handler http.Handler) error {
+		return nil
+	}
+
+	if err := Run(); err != nil {
+		t.Errorf("Expected success, got %v", err)
+	}
+}
+
+func TestRunSetupFailure(t *testing.T) {
+	oldSetup := apiSetupApp
+	defer func() { apiSetupApp = oldSetup }()
+
+	apiSetupApp = func(config models.Config, qm *queue.QueueManager) (*http.ServeMux, error) {
+		return nil, fmt.Errorf("setup fail")
+	}
+
+	if err := Run(); err == nil {
+		t.Error("Expected setup failure")
+	}
+}
+
+func TestMainFunc(t *testing.T) {
+	oldListen := httpListenAndServe
+	oldExit := osExit
+	defer func() {
+		httpListenAndServe = oldListen
+		osExit = oldExit
+	}()
+
+	// Test happy path
+	httpListenAndServe = func(addr string, handler http.Handler) error { return nil }
+	osExit = func(code int) { t.Errorf("osExit called with code %d", code) }
+	main()
+
+	// Test failure path
+	httpListenAndServe = func(addr string, handler http.Handler) error { return fmt.Errorf("fail") }
+	exitCalled := false
+	osExit = func(code int) { 
+		exitCalled = true 
+		if code != 1 { t.Errorf("Expected code 1, got %d", code) }
+	}
+	main()
+	if !exitCalled { t.Error("Expected osExit to be called") }
+}


### PR DESCRIPTION
The Docker build failed because cmd/uplarr/ was excluded by the unanchored 'uplarr' pattern in .gitignore which matched both the compiled binary and the source directory.

- Anchor all gitignore patterns with '/' prefix so they only match files at the repo root, not nested source directories
- Add previously untracked cmd/uplarr/main.go and main_test.go
- Remove stray test artifacts from internal/api/