### PR TITLE
fix(sse): add heartbeat keepalive to prevent proxy timeouts on /api/logs

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"crypto/rand"
 	"encoding/base64"
@@ -254,6 +255,8 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 		w.Header().Set("Connection", "keep-alive")
 		w.Header().Set("X-Accel-Buffering", "no")
 
+		// Send an initial SSE comment so proxies forward the response immediately.
+		_, _ = fmt.Fprint(w, ": connected\n\n")
 		if f, ok := w.(http.Flusher); ok {
 			f.Flush()
 		}
@@ -261,12 +264,21 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 		c := logger.Subscribe()
 		defer logger.Unsubscribe(c)
 
+		// Heartbeat ticker prevents reverse proxies from killing idle connections.
+		ticker := time.NewTicker(15 * time.Second)
+		defer ticker.Stop()
+
 		for {
 			select {
 			case <-r.Context().Done():
 				return
 			case msg := <-c:
 				_, _ = fmt.Fprintf(w, "data: %s\n\n", msg)
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+			case <-ticker.C:
+				_, _ = fmt.Fprint(w, ": keepalive\n\n")
 				if f, ok := w.(http.Flusher); ok {
 					f.Flush()
 				}


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Go version: <version>
* OS:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of log streaming functionality by implementing periodic keepalive signals, preventing connection timeouts during periods of inactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->