### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-21 - Added ARIA labels to icon buttons
+**Learning:** Screen readers cannot infer the purpose of icon-only buttons unless an `aria-label` or visible text is present. While the `title` attribute provides tooltips for mouse users, it is not consistently read by screen readers. Thus, providing an explicit `aria-label` is crucial for accessibility on components like toolbar icons.
+**Action:** Always include `aria-label` on icon-only buttons during initial development rather than waiting for an accessibility audit.

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -115,14 +115,14 @@
                 <div class="header-right" style="display: flex; gap: 12px; align-items: center;">
                     <div class="theme-picker">
                         <button class="theme-swatch" data-color="#38bdf8" style="background: #38bdf8"
-                            title="Sky"></button>
+                            title="Sky" aria-label="Sky theme"></button>
                         <button class="theme-swatch" data-color="#10b981" style="background: #10b981"
-                            title="Emerald"></button>
+                            title="Emerald" aria-label="Emerald theme"></button>
                         <button class="theme-swatch" data-color="#f43f5e" style="background: #f43f5e"
-                            title="Rose"></button>
+                            title="Rose" aria-label="Rose theme"></button>
                     </div>
                     <div class="dropdown">
-                        <button id="view-toggle-btn" class="glass-btn" title="View Options">
+                        <button id="view-toggle-btn" class="glass-btn" title="View Options" aria-label="Toggle view options">
                             <svg class="icon-inline" width="14" height="14">
                                 <use href="#icon-eye"></use>
                             </svg>
@@ -135,7 +135,7 @@
                             <label><input type="checkbox" id="toggle-global-compact"> Global Compact</label>
                         </div>
                     </div>
-                    <button id="logout-btn" class="glass-btn danger-btn" title="Logout">
+                    <button id="logout-btn" class="glass-btn danger-btn" title="Logout" aria-label="Logout">
                         <svg class="icon-inline" width="14" height="14">
                             <use href="#icon-logout"></use>
                         </svg>
@@ -165,14 +165,14 @@
                                 </div>
                                 <div class="pane-toolbar">
                                     <div class="toolbar-actions">
-                                        <button id="refresh-btn" title="Refresh"><svg class="icon-inline" width="12"
+                                        <button id="refresh-btn" title="Refresh" aria-label="Refresh local files"><svg class="icon-inline" width="12"
                                                 height="12">
                                                 <use href="#icon-refresh"></use>
                                             </svg></button>
-                                        <button id="up-btn" title="Up"><svg class="icon-inline" width="12" height="12">
+                                        <button id="up-btn" title="Up" aria-label="Go up local directory"><svg class="icon-inline" width="12" height="12">
                                                 <use href="#icon-up"></use>
                                             </svg></button>
-                                        <button id="mkdir-btn" title="New Folder"><svg class="icon-inline" width="12"
+                                        <button id="mkdir-btn" title="New Folder" aria-label="New local folder"><svg class="icon-inline" width="12"
                                                 height="12">
                                                 <use href="#icon-folder"></use>
                                             </svg></button>
@@ -209,15 +209,15 @@
                                 </div>
                                 <div class="pane-toolbar">
                                     <div class="toolbar-actions">
-                                        <button id="remote-refresh-btn" title="Refresh"><svg class="icon-inline"
+                                        <button id="remote-refresh-btn" title="Refresh" aria-label="Refresh remote files"><svg class="icon-inline"
                                                 width="12" height="12">
                                                 <use href="#icon-refresh"></use>
                                             </svg></button>
-                                        <button id="remote-up-btn" title="Up"><svg class="icon-inline" width="12"
+                                        <button id="remote-up-btn" title="Up" aria-label="Go up remote directory"><svg class="icon-inline" width="12"
                                                 height="12">
                                                 <use href="#icon-up"></use>
                                             </svg></button>
-                                        <button id="remote-mkdir-btn" title="New Folder"><svg class="icon-inline"
+                                        <button id="remote-mkdir-btn" title="New Folder" aria-label="New remote folder"><svg class="icon-inline"
                                                 width="12" height="12">
                                                 <use href="#icon-folder"></use>
                                             </svg></button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only buttons like refresh, new folder, up, view options, logout, and theme swatches in `ui/static/index.html`.
🎯 Why: Screen readers cannot infer the purpose of icon-only buttons reliably from `title` attributes alone. Providing `aria-label` explicitly improves accessibility and ensures users relying on assistive technologies have full context for actions.
♿ Accessibility: Improved screen reader navigation and compatibility by providing clear, descriptive labels for UI controls.

---
*PR created automatically by Jules for task [5557761085639519591](https://jules.google.com/task/5557761085639519591) started by @arumes31*