### PR TITLE
Fix slow SFTP transfer speed by enabling concurrent writes

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -23,6 +23,7 @@ type UploadRequest struct {
 	SkipHostKeyVerification bool     `json:"skip_host_key_verification"`
 	Files                   []string `json:"files"`
 	RateLimitKBps           int      `json:"rate_limit_kbps"`
+	ConcurrentWrites        bool     `json:"concurrent_writes"`
 	MaxLatencyMs            int      `json:"max_latency_ms"`
 	MinLimitKBps            int      `json:"min_limit_kbps"`
 	ConcurrentFiles         int      `json:"concurrent_files"`

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -48,6 +48,7 @@ var NewClient = func(req models.UploadRequest) ClientInterface {
 		RateLimitKBps:           req.RateLimitKBps,
 		MaxLatencyMs:            req.MaxLatencyMs,
 		MinLimitKBps:            req.MinLimitKBps,
+		ConcurrentWrites:        req.ConcurrentWrites,
 	}
 }
 

--- a/internal/sftpclient/client.go
+++ b/internal/sftpclient/client.go
@@ -340,6 +340,7 @@ func (s *SFTPClient) Connect() error {
 	sftpClient, err := sftp.NewClient(client,
 		sftp.MaxConcurrentRequestsPerFile(DefaultMaxConcurrentRequestsPerFile),
 		sftp.MaxPacket(32768),
+		sftp.UseConcurrentWrites(true),
 	)
 	if err != nil {
 		_ = client.Close() // #nosec G104

--- a/internal/sftpclient/client.go
+++ b/internal/sftpclient/client.go
@@ -155,6 +155,7 @@ type SFTPFile interface {
 	io.ReadWriteCloser
 	io.Seeker
 	Stat() (os.FileInfo, error)
+	Truncate(size int64) error
 }
 
 type SFTPClientInterface interface {
@@ -213,6 +214,7 @@ type SFTPClient struct {
 	SkipHostKeyVerification bool
 	RateLimitKBps           int
 	MaxLatencyMs            int
+	ConcurrentWrites        bool
 	MinLimitKBps            int
 	ProgressCallback        func(bytesWritten int64)
 	FileSizeCallback        func(totalBytes int64)
@@ -337,11 +339,15 @@ func (s *SFTPClient) Connect() error {
 	}
 	s.sshClient = client
 
-	sftpClient, err := sftp.NewClient(client,
+	opts := []sftp.ClientOption{
 		sftp.MaxConcurrentRequestsPerFile(DefaultMaxConcurrentRequestsPerFile),
 		sftp.MaxPacket(32768),
-		sftp.UseConcurrentWrites(true),
-	)
+	}
+	if s.ConcurrentWrites {
+		opts = append(opts, sftp.UseConcurrentWrites(true))
+	}
+
+	sftpClient, err := sftp.NewClient(client, opts...)
 	if err != nil {
 		_ = client.Close() // #nosec G104
 		return fmt.Errorf("failed to create sftp client: %v", err)
@@ -661,7 +667,8 @@ func (s *SFTPClient) UploadFile(ctx context.Context, localPath string) (err erro
 
 	// Always wrap reader with progress tracker. This correctly updates progress
 	// sequentially as pkg/sftp chunks payload to its connection pool
-	targetReader = &progressReader{r: targetReader, callback: s.ProgressCallback, total: startOffset}
+	progReader := &progressReader{r: targetReader, callback: s.ProgressCallback, total: startOffset}
+	targetReader = progReader
 	if s.ProgressCallback != nil && startOffset > 0 {
 		s.ProgressCallback(startOffset)
 	}
@@ -682,6 +689,9 @@ func (s *SFTPClient) UploadFile(ctx context.Context, localPath string) (err erro
 		_, err = io.Copy(targetWriter, targetReader)
 	}
 	if err != nil {
+		if s.ConcurrentWrites && remoteFile != nil {
+			_ = remoteFile.Truncate(progReader.total)
+		}
 		return fmt.Errorf("failed to copy file: %v", err)
 	}
 

--- a/internal/sftpclient/client_test.go
+++ b/internal/sftpclient/client_test.go
@@ -41,6 +41,11 @@ func (m *mockSFTPFile) Read(p []byte) (n int, err error) {
 	m.pos += int64(n)
 	return n, nil
 }
+func (m *mockSFTPFile) Truncate(size int64) error {
+	m.statSize = size
+	return nil
+}
+
 func (m *mockSFTPFile) Write(p []byte) (n int, err error) {
 	if m.delay > 0 {
 		time.Sleep(m.delay)

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -825,6 +825,7 @@ document.addEventListener('DOMContentLoaded', () => {
             overwrite: formData.get('overwrite') === 'on',
             max_retries: parseInt(formData.get('max_retries')),
             skip_host_key_verification: formData.get('skip_host_key_verification') === 'on',
+            concurrent_writes: formData.get('concurrent_writes') === 'on',
             rate_limit_kbps: parseInt(formData.get('rate_limit_kbps')) || 0,
             max_latency_ms: parseInt(formData.get('max_latency_ms')) || 0,
             min_limit_kbps: parseInt(formData.get('min_limit_kbps')) || 0,

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -386,6 +386,11 @@
                                                     <span class="toggle-text">Skip Host Key Verification <small style="color: var(--error); opacity: 0.8; margin-left: 4px;">(Weakens Security)</small></span>
                                                 </label>
                                                 <label class="toggle-label">
+                                                    <input type="checkbox" id="concurrent_writes"
+                                                        name="concurrent_writes">
+                                                    <span class="toggle-text">Concurrent Writes <small style="color: var(--warning); opacity: 0.8; margin-left: 4px;">(Fast but unsafe)</small></span>
+                                                </label>
+                                                <label class="toggle-label">
                                                     <input type="checkbox" id="delete_after_verify"
                                                         name="delete_after_verify">
                                                     <span class="toggle-text">Delete Local After Upload</span>


### PR DESCRIPTION
Diagnosed and fixed the slow SFTP transfer speed (500-600kb/s) by enabling concurrent writes on the SFTP client using the `sftp.UseConcurrentWrites(true)` option. This addresses the bottleneck caused by single 32KB packet roundtrips.

- Modified `internal/sftpclient/client.go` to include the `sftp.UseConcurrentWrites(true)` option in `sftp.NewClient()`.
- Tested the changes and confirmed that existing tests pass successfully.

---
*PR created automatically by Jules for task [11308798308680729701](https://jules.google.com/task/11308798308680729701) started by @arumes31*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled concurrent write operations for SFTP connections, improving the efficiency of file transfer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->