### PR TITLE
🎨 Palette: Add ARIA labels and focus/disabled visual states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-04-21 - Added ARIA labels to icon buttons
 **Learning:** Screen readers cannot infer the purpose of icon-only buttons unless an `aria-label` or visible text is present. While the `title` attribute provides tooltips for mouse users, it is not consistently read by screen readers. Thus, providing an explicit `aria-label` is crucial for accessibility on components like toolbar icons.
 **Action:** Always include `aria-label` on icon-only buttons during initial development rather than waiting for an accessibility audit.
+
+## 2024-05-18 - Added disabled visual feedback and focus indicators
+**Learning:** Screen readers announce `:disabled` buttons appropriately, but without explicit styling, visually impaired or keyboard-only users miss the feedback that a task like an upload or connection attempt is in progress. Adding focus states ensures users tabbing through can see their position.
+**Action:** Always include a visual state for disabled inputs and ensure `:focus-visible` exists on interactive elements.

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -178,7 +178,7 @@
                                             </svg></button>
                                     </div>
                                     <div class="toolbar-search">
-                                        <input type="search" id="local-search" placeholder="Filter...">
+                                        <input type="search" id="local-search" placeholder="Filter..." aria-label="Filter local files">
                                     </div>
                                     <button id="compact-toggle" class="compact-toggle"
                                         title="Compact List">Compact</button>
@@ -187,7 +187,7 @@
                                     <table id="file-table" class="file-table">
                                         <thead>
                                             <tr>
-                                                <th class="col-check"><input type="checkbox" id="select-all-checkbox">
+                                                <th class="col-check"><input type="checkbox" id="select-all-checkbox" aria-label="Select all local files">
                                                 </th>
                                                 <th class="col-name sortable" data-sort="name">Name <span
                                                         class="sort-arrow">▲</span></th>
@@ -223,7 +223,7 @@
                                             </svg></button>
                                     </div>
                                     <div class="toolbar-search">
-                                        <input type="search" id="remote-search" placeholder="Filter...">
+                                        <input type="search" id="remote-search" placeholder="Filter..." aria-label="Filter remote files">
                                     </div>
                                     <button id="remote-compact-toggle" class="compact-toggle"
                                         title="Compact List">Compact</button>
@@ -433,7 +433,7 @@
                         <section class="logs-section section-logs">
                             <div class="section-header">
                                 <h3>Logs</h3>
-                                <input type="text" id="log-search" placeholder="Filter..." class="search-input-sm">
+                                <input type="text" id="log-search" placeholder="Filter..." class="search-input-sm" aria-label="Filter logs">
                             </div>
                             <div id="log-container" class="log-window"></div>
                         </section>

--- a/ui/static/style.css
+++ b/ui/static/style.css
@@ -720,6 +720,15 @@ section { padding: 8px 12px; }
     border-radius: 3px;
 }
 
+/* General focus states for accessibility */
+button:focus-visible,
+input:focus-visible,
+a:focus-visible,
+[role="button"]:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: 2px;
+}
+
 /* Buttons */
 button {
     font-family: var(--font-main);
@@ -733,6 +742,12 @@ button {
     display: inline-flex;
     align-items: center;
     gap: 4px;
+}
+
+button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    filter: grayscale(100%);
 }
 
 .glass-btn { background: rgba(255,255,255,0.05); color: var(--text-main); border: 1px solid var(--glass-border); }


### PR DESCRIPTION
💡 What: Added ARIA labels to search inputs and the select all checkbox. Also added a visible outline for keyboard focus and disabled button styles in CSS.
🎯 Why: Screen readers could not easily announce the purpose of some icon-only tools or generic inputs. Visually impaired or keyboard-only users lacked visual feedback for focus navigation and disabled interactive states.
♿ Accessibility: Improved keyboard navigation with explicit `:focus-visible` states, proper ARIA labels, and explicit `:disabled` visual changes.

---
*PR created automatically by Jules for task [168461572520671246](https://jules.google.com/task/168461572520671246) started by @arumes31*