### PR TITLE
⚡ Bolt: Avoid disk I/O in Mutex critical sections for GetTasks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-05-24 - Debouncing frontend rendering
 **Learning:** Filtering DOM events like keystrokes when rendering large file lists is crucial to avoid jank. Debouncing search inputs was needed here.
 **Action:** Always look for debounce/throttle opportunities when filtering large UI lists in vanilla JS.
+
+## 2025-05-25 - Avoid disk I/O in Mutex critical sections
+**Learning:** Holding a read/write mutex while performing synchronous disk operations (like `os.Stat`) in a frequently polled endpoint creates massive lock contention and slows down the entire application (e.g., UI freezing, workers blocked).
+**Action:** Always extract disk I/O out of the locked scope. Take a quick snapshot of the needed data in memory while locked, release the lock, and then perform the slow I/O operations on the snapshot.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -459,15 +459,9 @@ func (qm *QueueManager) processTask(nextTask *models.Task) {
 
 func (qm *QueueManager) GetTasks() []*models.Task {
 	qm.mu.RLock()
-	defer qm.mu.RUnlock()
 	snapshot := make([]*models.Task, len(qm.tasks))
 	for i, t := range qm.tasks {
 		copyTask := *t
-		// Check if local file still exists
-		fullPath := filepath.Join(qm.localDir, t.FileName)
-		_, err := os.Stat(fullPath)
-		copyTask.LocalFileExists = (err == nil)
-
 		// Deep-copy mutable reference fields so snapshot doesn't share state
 		if t.Config.Files != nil {
 			copyTask.Config.Files = make([]string, len(t.Config.Files))
@@ -475,6 +469,19 @@ func (qm *QueueManager) GetTasks() []*models.Task {
 		}
 		snapshot[i] = &copyTask
 	}
+	qm.mu.RUnlock()
+
+	for _, copyTask := range snapshot {
+		// Only check if local file exists for states that actually need it (for Retry UI)
+		if copyTask.Status == models.TaskFailed || copyTask.Status == models.TaskCompleted {
+			fullPath := filepath.Join(qm.localDir, copyTask.FileName)
+			_, err := os.Stat(fullPath)
+			copyTask.LocalFileExists = (err == nil)
+		} else {
+			copyTask.LocalFileExists = true // Default for pending/running where we don't care to stat yet
+		}
+	}
+
 	return snapshot
 }
 


### PR DESCRIPTION
💡 What: Refactored `QueueManager.GetTasks()` to extract synchronous `os.Stat` disk I/O out of the mutex critical section, and only check the filesystem for completed/failed tasks.
🎯 Why: `GetTasks` is polled periodically by the UI. Previously, calling `os.Stat` while holding `qm.mu.RLock()` would cause major lock contention, blocking workers and freezing the UI when disk I/O was slow or the queue was large. 
📊 Impact: Effectively eliminates RWMutex contention during `/api/queue` polling.
🔬 Measurement: Can be verified by running `go test ./...` and observing application responsiveness when checking the task queue while uploading heavy files.

---
*PR created automatically by Jules for task [12092403371344244259](https://jules.google.com/task/12092403371344244259) started by @arumes31*