### PR TITLE
🎨 Palette: Add ARIA states to view toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-05 - Adding accessibility to toggle buttons
+**Learning:** Found that layout toggles (`view-toggle-btn`) and view options (`compact-toggle`) missed dynamic ARIA attributes, leaving screen reader users without proper context of the current interface state.
+**Action:** When creating toggle buttons or dropdown buttons, always pair with `aria-pressed` or `aria-expanded` and `aria-haspopup` to properly convey state changes and control relationships.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -158,7 +158,9 @@ document.addEventListener('DOMContentLoaded', () => {
         remotePane.classList.toggle('compact', compactState.remote);
         document.body.classList.toggle('global-compact', compactState.global);
         compactToggle.classList.toggle('active', compactState.local);
+        compactToggle.setAttribute('aria-pressed', compactState.local.toString());
         remoteCompactToggle.classList.toggle('active', compactState.remote);
+        remoteCompactToggle.setAttribute('aria-pressed', compactState.remote.toString());
         if (toggleGlobalCompact) toggleGlobalCompact.checked = !!compactState.global;
     };
     
@@ -566,11 +568,15 @@ document.addEventListener('DOMContentLoaded', () => {
     // Layout Toggles
     viewToggleBtn.addEventListener('click', (e) => {
         e.stopPropagation();
-        viewMenu.classList.toggle('hidden');
+        const isHidden = viewMenu.classList.toggle('hidden');
+        viewToggleBtn.setAttribute('aria-expanded', (!isHidden).toString());
     });
 
     document.addEventListener('click', (e) => {
-        if (!viewMenu.contains(e.target)) viewMenu.classList.add('hidden');
+        if (!viewMenu.contains(e.target)) {
+            viewMenu.classList.add('hidden');
+            viewToggleBtn.setAttribute('aria-expanded', 'false');
+        }
     });
 
     ['metrics', 'queue', 'logs'].forEach(id => {

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -122,7 +122,7 @@
                             title="Rose" aria-label="Rose theme"></button>
                     </div>
                     <div class="dropdown">
-                        <button id="view-toggle-btn" class="glass-btn" title="View Options" aria-label="Toggle view options">
+                        <button id="view-toggle-btn" class="glass-btn" title="View Options" aria-label="Toggle view options" aria-haspopup="menu" aria-expanded="false">
                             <svg class="icon-inline" width="14" height="14">
                                 <use href="#icon-eye"></use>
                             </svg>
@@ -181,7 +181,7 @@
                                         <input type="search" id="local-search" placeholder="Filter..." aria-label="Filter local files">
                                     </div>
                                     <button id="compact-toggle" class="compact-toggle"
-                                        title="Compact List">Compact</button>
+                                        title="Compact List" aria-pressed="false">Compact</button>
                                 </div>
                                 <div class="file-list-container">
                                     <table id="file-table" class="file-table">
@@ -226,7 +226,7 @@
                                         <input type="search" id="remote-search" placeholder="Filter..." aria-label="Filter remote files">
                                     </div>
                                     <button id="remote-compact-toggle" class="compact-toggle"
-                                        title="Compact List">Compact</button>
+                                        title="Compact List" aria-pressed="false">Compact</button>
                                 </div>
                                 <div class="file-list-container">
                                     <table id="remote-file-table" class="file-table">


### PR DESCRIPTION
💡 What: Added missing `aria-expanded` and `aria-pressed` states to dynamic view toggles.
🎯 Why: Enhances accessibility by providing screen reader users with necessary context about the active layout options and dropdown states.
📸 Before/After: N/A (non-visual structural accessibility change)
♿ Accessibility:
- Added `aria-haspopup="menu"` and dynamically updated `aria-expanded` to `#view-toggle-btn`.
- Added dynamic `aria-pressed` state to `#compact-toggle` and `#remote-compact-toggle` buttons.

---
*PR created automatically by Jules for task [12486295937467611114](https://jules.google.com/task/12486295937467611114) started by @arumes31*