### PR TITLE
🎨 Palette: Add inline loading states to primary action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-05-18 - Added disabled visual feedback and focus indicators
 **Learning:** Screen readers announce `:disabled` buttons appropriately, but without explicit styling, visually impaired or keyboard-only users miss the feedback that a task like an upload or connection attempt is in progress. Adding focus states ensures users tabbing through can see their position.
 **Action:** Always include a visual state for disabled inputs and ensure `:focus-visible` exists on interactive elements.
+## 2024-04-24 - Preserving Button Icons & Providing Inline Loading States
+**Learning:** Overwriting the entire `.textContent` of a button that contains an inline icon (like `<svg>`) accidentally destroys the icon. Furthermore, users often lack immediate feedback on buttons like "Connect" or "Upload" while the action is processing, making the UI feel unresponsive even if a toast appears.
+**Action:** Always wrap button text in a `<span class="btn-text">` when the button also contains an SVG icon. Create a reusable `toggleButtonLoading` utility that toggles visibility between the static icon and a spinner icon, and temporarily updates the `.btn-text` content to reflect the loading state (e.g., "Connecting...").

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -883,7 +883,36 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
     const updateUploadButtonText = () => {
-        uploadBtn.textContent = queuedFiles.size > 0 ? `Queue ${queuedFiles.size} Files` : "Queue All Files";
+        const textSpan = uploadBtn.querySelector('.btn-text');
+        if (textSpan) {
+            textSpan.textContent = queuedFiles.size > 0 ? `Queue ${queuedFiles.size} Files` : "Queue All Files";
+        } else {
+            uploadBtn.textContent = queuedFiles.size > 0 ? `Queue ${queuedFiles.size} Files` : "Queue All Files";
+        }
+    };
+
+    const toggleButtonLoading = (btn, isLoading, loadingText = "Loading...", restoreFn = null) => {
+        if (!btn) return;
+        const icon = btn.querySelector('.btn-icon');
+        const spinner = btn.querySelector('.btn-spinner');
+        const textSpan = btn.querySelector('.btn-text');
+
+        if (isLoading) {
+            if (icon) icon.classList.add('hidden');
+            if (spinner) spinner.classList.remove('hidden');
+            if (textSpan) {
+                btn.dataset.originalText = textSpan.textContent;
+                textSpan.textContent = loadingText;
+            }
+        } else {
+            if (icon) icon.classList.remove('hidden');
+            if (spinner) spinner.classList.add('hidden');
+            if (restoreFn) {
+                restoreFn();
+            } else if (textSpan && btn.dataset.originalText) {
+                textSpan.textContent = btn.dataset.originalText;
+            }
+        }
     };
 
     // --- Local Files ---
@@ -1452,6 +1481,7 @@ document.addEventListener('DOMContentLoaded', () => {
         testBtn.addEventListener('click', async () => {
             const config = getFormData();
             testBtn.disabled = true;
+            toggleButtonLoading(testBtn, true, "Connecting...");
             showStatus("Connecting...", "info");
             try {
                 const res = await fetch('/api/test-connection', { 
@@ -1464,6 +1494,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 else showStatus(`Failed: ${data.error || "Unknown error"}`, "error");
             } catch (e) { showStatus("Request failed", "error"); }
             testBtn.disabled = false;
+            toggleButtonLoading(testBtn, false);
         });
     }
 
@@ -1471,6 +1502,7 @@ document.addEventListener('DOMContentLoaded', () => {
         updateThrottleBtn.addEventListener('click', async () => {
             const config = getFormData();
             updateThrottleBtn.disabled = true;
+            toggleButtonLoading(updateThrottleBtn, true, "Applying...");
             try {
                 const res = await fetch('/api/throttle/update', { 
                     method: 'POST', 
@@ -1486,6 +1518,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             } catch (e) { showStatus("Request failed", "error"); }
             updateThrottleBtn.disabled = false;
+            toggleButtonLoading(updateThrottleBtn, false);
         });
     }
 
@@ -1520,6 +1553,7 @@ document.addEventListener('DOMContentLoaded', () => {
         addLog(`Queueing ${filesToUpload.length} files to: ${config.remote_dir}`, 'info');
         
         uploadBtn.disabled = true;
+        toggleButtonLoading(uploadBtn, true, "Queueing...");
         try {
             const res = await fetch('/api/upload', { 
                 method: 'POST', 
@@ -1538,6 +1572,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         } catch (e) { showStatus("Upload request failed", "error"); }
         uploadBtn.disabled = false;
+        toggleButtonLoading(uploadBtn, false, "", updateUploadButtonText);
     });
 }
 

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -397,11 +397,12 @@
                                             </div>
                                             <div class="adv-actions">
                                                 <button type="button" id="update-throttle-btn" class="glass-btn-sm">
-                                                    <svg class="icon-inline" width="12" height="12" viewBox="0 0 24 24"
+                                                    <svg class="icon-inline btn-icon" width="12" height="12" viewBox="0 0 24 24"
                                                         fill="none" stroke="currentColor" stroke-width="2">
                                                         <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
                                                     </svg>
-                                                    Apply Throttling
+                                                    <svg class="icon-inline btn-spinner hidden" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>
+                                                    <span class="btn-text">Apply Throttling</span>
                                                 </button>
                                             </div>
                                         </div>
@@ -409,21 +410,23 @@
 
                                     <div class="config-actions">
                                         <button type="button" id="test-btn" class="connect-btn">
-                                            <svg class="icon-inline" width="14" height="14" viewBox="0 0 24 24"
+                                            <svg class="icon-inline btn-icon" width="14" height="14" viewBox="0 0 24 24"
                                                 fill="none" stroke="currentColor" stroke-width="2"
                                                 stroke-linecap="round" stroke-linejoin="round">
                                                 <path d="M5 12h14M12 5l7 7-7 7" />
                                             </svg>
-                                            Connect
+                                            <svg class="icon-inline btn-spinner hidden" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>
+                                            <span class="btn-text">Connect</span>
                                         </button>
                                         <button type="button" id="upload-btn" class="primary-btn">
-                                            <svg class="icon-inline" width="14" height="14" viewBox="0 0 24 24"
+                                            <svg class="icon-inline btn-icon" width="14" height="14" viewBox="0 0 24 24"
                                                 fill="none" stroke="currentColor" stroke-width="2"
                                                 stroke-linecap="round" stroke-linejoin="round">
                                                 <path
                                                     d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12" />
                                             </svg>
-                                            Upload Selected
+                                            <svg class="icon-inline btn-spinner hidden" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>
+                                            <span class="btn-text">Upload Selected</span>
                                         </button>
                                     </div>
                                 </form>

--- a/ui/static/style.css
+++ b/ui/static/style.css
@@ -789,6 +789,18 @@ button:disabled {
 .toast-container { position: fixed; bottom: 20px; right: 20px; z-index: 2000; display: flex; flex-direction: column; gap: 8px; }
 .toast { width: 260px; padding: 8px 12px; background: rgba(18,26,46,0.9); border: 1px solid var(--glass-border); border-radius: 8px; font-size: 0.8rem; }
 
+/* Button Loading States */
+.btn-spinner {
+    animation: rotate 2s linear infinite;
+    transform-origin: center;
+}
+
+@keyframes rotate {
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
 /* Blobs */
 .bg-blobs { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: -1; filter: blur(80px); opacity: 0.3; }
 .blob { position: absolute; border-radius: 50%; }


### PR DESCRIPTION
🎨 Palette: Add inline loading states to primary action buttons

* **What:** Added a `.btn-spinner` SVG and `.btn-text` span to the `upload-btn`, `test-btn`, and `update-throttle-btn`. Created a `toggleButtonLoading` utility in `app.js` to manage showing a loading spinner and changing button text (e.g., "Connecting...") while an API request is in progress.
* **Why:** Previously, these buttons only gave visual feedback via `opacity: 0.5` (disabled state). Adding a spinner and explicit loading text makes the interface feel more responsive and reassures the user that an action is occurring. Also fixes a bug where `uploadBtn.textContent = ...` destroyed its sibling SVG icon.
* **Accessibility:** Screen readers will now read the updated text (e.g., "Queueing..."), providing better context during network requests.

---
*PR created automatically by Jules for task [2794923805722448617](https://jules.google.com/task/2794923805722448617) started by @arumes31*