### PR TITLE
🎨 Palette: Empty states for tables and modal cleanup

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-05 - Adding accessibility to toggle buttons
 **Learning:** Found that layout toggles (`view-toggle-btn`) and view options (`compact-toggle`) missed dynamic ARIA attributes, leaving screen reader users without proper context of the current interface state.
 **Action:** When creating toggle buttons or dropdown buttons, always pair with `aria-pressed` or `aria-expanded` and `aria-haspopup` to properly convey state changes and control relationships.
+## 2024-05-18 - Added Empty States for Queues and Lists
+**Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
+**Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -936,6 +936,17 @@ document.addEventListener('DOMContentLoaded', () => {
         updateSortHeaders('file-table', localSort);
         fileListBody.innerHTML = '';
 
+        if (sorted.length === 0) {
+            const row = document.createElement('tr');
+            const td = document.createElement('td');
+            td.colSpan = 4;
+            td.className = 'empty-msg';
+            td.textContent = localFilter ? `No files matching "${localFilter}"` : 'This folder is empty';
+            row.appendChild(td);
+            fileListBody.appendChild(row);
+            return;
+        }
+
         sorted.forEach(file => {
             const fullRelPath = currentPath ? `${currentPath}/${file.name}` : file.name;
             const row = document.createElement('tr');
@@ -1298,6 +1309,17 @@ document.addEventListener('DOMContentLoaded', () => {
             
             let activeBytesSum = 0;
             queueBody.innerHTML = '';
+
+            if (tasks.length === 0) {
+                const row = document.createElement('tr');
+                const td = document.createElement('td');
+                td.colSpan = 6;
+                td.className = 'empty-msg';
+                td.textContent = 'Queue is empty. Select files to start transferring.';
+                row.appendChild(td);
+                queueBody.appendChild(row);
+            }
+
             tasks.reverse().forEach(task => {
                 if (task.status !== 'Completed') {
                     activeBytesSum += task.bytes_uploaded;

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -480,23 +480,8 @@
         <div class="modal-content glass-panel">
             <h3>Mass Rename</h3>
             <div class="rename-inputs">
-                <input type="text" id="rename-search" placeholder="Search (Regex supported)">
-                <input type="text" id="rename-replace" placeholder="Replace (use $idx for sequence)">
-            </div>
-            <div id="rename-preview" class="rename-preview"></div>
-            <div class="modal-actions">
-                <button id="rename-cancel-btn" class="secondary-btn">Cancel</button>
-                <button id="rename-confirm-btn" class="primary-btn">Apply Rename</button>
-            </div>
-        </div>
-    </div>
-
-    <div id="rename-modal" class="modal hidden">
-        <div class="modal-content glass-panel">
-            <h3>Mass Rename</h3>
-            <div class="rename-inputs">
-                <input type="text" id="rename-search" placeholder="Search (Regex supported)">
-                <input type="text" id="rename-replace" placeholder="Replace (use $idx for sequence)">
+                <input type="text" id="rename-search" placeholder="Search (Regex supported)" aria-label="Search pattern">
+                <input type="text" id="rename-replace" placeholder="Replace (use $idx for sequence)" aria-label="Replacement pattern">
             </div>
             <div id="rename-preview" class="rename-preview"></div>
             <div class="modal-actions">

--- a/ui/static/style.css
+++ b/ui/static/style.css
@@ -807,3 +807,4 @@ button:disabled {
 .blob-1 { width: 300px; height: 300px; top: -50px; left: -50px; background: var(--accent-primary); }
 .blob-2 { width: 400px; height: 400px; bottom: -100px; right: -100px; background: var(--accent-secondary); }
 .blob-3 { width: 200px; height: 200px; top: 30%; left: 50%; background: var(--accent-primary); }
+.empty-msg { text-align: center; color: var(--text-muted); font-style: italic; padding: 24px !important; }


### PR DESCRIPTION
💡 What: Added empty states for the local file browser and the background task queue. Cleaned up a duplicate rename modal and added ARIA labels to the remaining rename inputs.
🎯 Why: Tables that are initially empty appear broken if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion. Duplicate modals bloat the DOM and ARIA labels improve accessibility for screen readers.
📸 Before/After: See generated screenshot.
♿ Accessibility: Added `aria-label` to mass rename modal inputs.

---
*PR created automatically by Jules for task [13371830107264082325](https://jules.google.com/task/13371830107264082325) started by @arumes31*