### PR TITLE
⚡ Bolt: O(N) optimization for GetHostStats

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+## 2025-05-26 - O(N²) Lock Contention in GetHostStats
+**Learning:** `GetHostStats` was iterating over all tasks inside a host loop while holding an RLock, resulting in O(N²) traversal. In a long-polling or fast-polling endpoint, this causes lock contention, slowing down other operations holding the write lock.
+**Action:** When returning stats derived from lists within a read lock, use an O(N) map aggregation to pre-calculate the subset needed, reducing iteration overhead inside the critical section.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,52 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	// ⚡ Bolt: Pre-calculate task statistics per host in O(N) to avoid O(N²) nested loops
+	type hostAgg struct {
+		hasActiveTasks bool
+		activeCount    int
+		hostSpeedBps   float64
+	}
+
+	agg := make(map[string]*hostAgg)
+	for host := range qm.limiters {
+		agg[host] = &hostAgg{}
+	}
+
+	for _, t := range qm.tasks {
+		a, ok := agg[t.Config.Host]
+		if !ok {
+			continue // Should not happen for valid tasks, but safe fallback
 		}
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			a.hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				a.activeCount++
 
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						a.hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
+
+	var stats []models.HostStats
+	for host, limiter := range qm.limiters {
+		a := agg[host]
+		if a != nil && a.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    a.activeCount,
+				TotalSpeedKBps: a.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 What: Refactored `GetHostStats` in `internal/queue/manager.go` to use an O(N) hash map to aggregate task statistics before formatting the host stats, eliminating the previous nested O(N²) loop structure.
🎯 Why: `GetHostStats` is called frequently (1s polling interval) by the frontend. The previous code iterated over all tasks *for every host* inside a read-lock (`mu.RLock`), causing O(N²) time complexity. With a large queue and many hosts, this locks up the queue manager and starves write operations.
📊 Impact: Reduces time complexity of computing host metrics from O(N²) to O(N). Significantly reduces read-lock holding time, avoiding jank for other concurrent operations and UI polling.
🔬 Measurement: Run a large upload queue with many files (e.g. 500+) across multiple hosts. Observe API response times for `/api/stats` and overall CPU usage of the queue manager. The API latency will remain stable and the lock will be freed faster.

---
*PR created automatically by Jules for task [13985582374276021430](https://jules.google.com/task/13985582374276021430) started by @arumes31*