### PR TITLE
🎨 Palette: Add context-aware ARIA labels to queue actions and checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2026-03-05 - Adding accessible context to dynamic table actions
+**Learning:** Dynamically generated action buttons inside data tables (like pause, retry, and remove buttons in the task queue) often lack explicit screen reader context when multiple rows have identical button labels. A screen reader reading 'Remove' doesn't explain what item is being removed.
+**Action:** When rendering iterative actions in lists or tables, dynamically attach context-aware `aria-label` attributes to those buttons (e.g., 'Remove [filename]') to make them fully accessible.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,6 +976,7 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
+            cb.setAttribute('aria-label', 'Select ' + file.name);
             if (file.is_dir) cb.disabled = true;
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
@@ -1400,6 +1401,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
                     controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.setAttribute('aria-label', (task.status === 'Paused' ? 'Resume ' : 'Pause ') + task.file_name);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1407,6 +1409,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', 'Retry ' + task.file_name);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1414,6 +1417,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', 'Remove ' + task.file_name);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
### 🎨 Palette: Micro-UX & Accessibility Polish

**💡 What:** 
Added context-aware `aria-label` attributes to dynamically created checkboxes in the file list and action buttons in the queue table (Pause, Resume, Retry, Remove). Also logged this critical accessibility insight in the Palette journal.

**🎯 Why:**
Previously, screen readers would only announce generic labels like "Remove" or "Retry" inside the queue table, or encounter unlabelled checkboxes in the file browser. This left users without context on *which* file they were acting upon. Now, labels are dynamic (e.g., "Remove filename.txt", "Select filename.txt"), making the interface fully accessible and intuitive for screen reader users.

**📸 Before/After:** 
No visual layout changes (kept under 50 lines), but the underlying screen reader context has been greatly improved.

**♿ Accessibility:**
- Contextual `aria-label` applied to dynamically generated table actions.
- Checkboxes in local file list now explicitly label the file they relate to.
- Safe DOM updates via `.setAttribute` directly in vanilla JS.

---
*PR created automatically by Jules for task [16699228025581081597](https://jules.google.com/task/16699228025581081597) started by @arumes31*