### PR TITLE
🎨 Palette: Keyboard Accessibility for Custom Table Rows

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2024-05-18 - Keyboard Accessibility for Custom Table Rows
+**Learning:** Found that custom table rows used as interactive elements (e.g., clicking a directory row to navigate) lack built-in keyboard accessibility, making navigation impossible for non-mouse users.
+**Action:** Whenever using non-interactive elements (like `<tr>` or `<div>`) as clickable items, always assign `role="button"`, `tabindex="0"`, and attach a `keydown` event listener to trigger the action on Enter or Space keys, while also providing `:focus-visible` styles.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -953,8 +953,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (file.is_dir) {
                 row.className = 'clickable-row folder-row';
+                row.tabIndex = 0;
+                row.setAttribute('role', 'button');
                 row.addEventListener('click', (e) => {
                     if (e.target.type !== 'checkbox') fetchFiles(fullRelPath);
+                });
+                row.addEventListener('keydown', (e) => {
+                    if (e.target.type !== 'checkbox' && (e.key === 'Enter' || e.key === ' ')) {
+                        e.preventDefault();
+                        fetchFiles(fullRelPath);
+                    }
                 });
             } else {
                 row.draggable = true;
@@ -1131,9 +1139,18 @@ document.addEventListener('DOMContentLoaded', () => {
             const row = document.createElement('tr');
             if (file.is_dir) {
                 row.className = 'clickable-row folder-row';
+                row.tabIndex = 0;
+                row.setAttribute('role', 'button');
                 row.addEventListener('click', () => {
                     const newPath = remoteCurrentPath.endsWith('/') ? remoteCurrentPath + file.name : remoteCurrentPath + '/' + file.name;
                     fetchRemoteFiles(newPath);
+                });
+                row.addEventListener('keydown', (e) => {
+                    if (e.target.type !== 'checkbox' && (e.key === 'Enter' || e.key === ' ')) {
+                        e.preventDefault();
+                        const newPath = remoteCurrentPath.endsWith('/') ? remoteCurrentPath + file.name : remoteCurrentPath + '/' + file.name;
+                        fetchRemoteFiles(newPath);
+                    }
                 });
             }
 

--- a/ui/static/style.css
+++ b/ui/static/style.css
@@ -724,9 +724,14 @@ section { padding: 8px 12px; }
 button:focus-visible,
 input:focus-visible,
 a:focus-visible,
-[role="button"]:focus-visible {
+[role="button"]:focus-visible,
+.clickable-row:focus-visible {
     outline: 2px solid var(--accent-primary);
     outline-offset: 2px;
+}
+
+.clickable-row:focus-visible {
+    outline-offset: -2px;
 }
 
 /* Buttons */


### PR DESCRIPTION
💡 What: Added keyboard navigability to custom folder rows within local and remote file tables.
🎯 Why: The previous implementation relied solely on mouse clicks, breaking accessibility and preventing keyboard-only users from interacting with folders.
📸 Before/After: Local and remote folders now support `tabIndex`, screen-reader `role="button"`, and `:focus-visible` highlighting.
♿ Accessibility: Ensures full keyboard interaction (Enter/Space to fetch files) while explicitly ignoring events triggered by checking inner checkboxes.

---
*PR created automatically by Jules for task [13392068886371536253](https://jules.google.com/task/13392068886371536253) started by @arumes31*