### PR TITLE
⚡ Bolt: Remove O(n) disk I/O from queue polling endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2025-05-25 - Avoid O(N) disk I/O in polled endpoints
+**Learning:** Checking file existence (`os.Stat`) inside a frequently polled endpoint (like `/api/queue`) creates massive disk I/O overhead as the number of items grows, even outside of mutex critical sections.
+**Action:** Shift file existence validation from "display-time" to "action-time". For UI states, assume the file exists to skip the read, and validate it when the user actually attempts to act on it (e.g. click Retry).

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -472,14 +472,10 @@ func (qm *QueueManager) GetTasks() []*models.Task {
 	qm.mu.RUnlock()
 
 	for _, copyTask := range snapshot {
-		// Only check if local file exists for states that actually need it (for Retry UI)
-		if copyTask.Status == models.TaskFailed || copyTask.Status == models.TaskCompleted {
-			fullPath := filepath.Join(qm.localDir, copyTask.FileName)
-			_, err := os.Stat(fullPath)
-			copyTask.LocalFileExists = (err == nil)
-		} else {
-			copyTask.LocalFileExists = true // Default for pending/running where we don't care to stat yet
-		}
+		// ⚡ Bolt: Removed os.Stat from this polled endpoint to prevent O(n) disk I/O.
+		// The backend will instead validate file existence in ControlTask when a retry is actually attempted.
+		// Impact: Eliminates mass disk I/O on every UI queue poll for completed/failed tasks.
+		copyTask.LocalFileExists = true
 	}
 
 	return snapshot

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,13 @@
+1. **Remove `os.Stat` from `GetTasks()`:**
+   - In `internal/queue/manager.go`, the `GetTasks()` method currently executes an `os.Stat` call for every task in the `TaskFailed` or `TaskCompleted` state.
+   - Remove the `os.Stat` call inside the `snapshot` loop.
+   - Set `copyTask.LocalFileExists = true` unconditionally for all tasks in the snapshot.
+   - This eliminates O(N) disk I/O operations from `GetTasks()`, relying instead on the existing `os.Stat` validation within `ControlTask` when a retry action is actually invoked.
+
+2. **Run tests:**
+   - Run `go test ./...` to verify the changes do not break any existing backend logic.
+   - Ensure the codebase builds correctly with `go run ./cmd/uplarr`.
+
+3. **Complete pre-commit steps:** Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+
+4. **Submit Change:** Create a PR with title "⚡ Bolt: Remove O(n) disk I/O from queue polling endpoint".


### PR DESCRIPTION
**💡 What:** Removed the synchronous `os.Stat` call inside the `GetTasks()` snapshot loop in `internal/queue/manager.go`, conditionally rendering the UI "Retry" button based on an assumption of file presence.

**🎯 Why:** The UI polls the queue endpoint (`/api/queue`) every 1 second. Previously, the backend verified if the local file still existed for every single completed or failed task by executing `os.Stat`. If a user had thousands of tasks in history, this caused thousands of disk I/O operations every second. This change shifts validation from display-time to action-time (validation now properly occurs in `ControlTask` when a user actually clicks "Retry").

**📊 Impact:** Eliminates an `O(N)` disk I/O bottleneck in the queue poll. Significantly lowers CPU utilization and massive disk I/O on large queues.

**🔬 Measurement:** Verified by code review and testing. You can measure by inspecting syscalls (e.g. `strace -c`) during idle UI polling when having many completed tasks in the queue; the `stat` syscall count drops drastically.

---
*PR created automatically by Jules for task [3963230333020582221](https://jules.google.com/task/3963230333020582221) started by @arumes31*