### PR TITLE
🎨 Palette: Improve accessibility of dynamic file table checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+
+## 2025-02-23 - Added Accessibility to Dynamic Checkboxes
+**Learning:** Dynamically generated checkboxes in file tables without labels are completely invisible to screen readers, and disabled checkboxes without an explanation or tooltip cause confusion because users don't know why they cannot interact with them.
+**Action:** When dynamically generating checkboxes using JS, always set an `aria-label` to provide the necessary context (e.g., "Select file: X"). For dynamically disabled inputs, always add a `title` explaining the reason for the disabled state to improve clarity.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.is_dir ? 'directory' : 'file'}: ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = "Directories cannot be selected directly";
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 **What:** Added `aria-label` to file checkboxes and `title` to disabled directory checkboxes in the file table.
🎯 **Why:** Dynamically generated checkboxes in file tables lacked labels, making them invisible to screen readers. Disabled directory checkboxes caused confusion because users did not know why they could not interact with them.
📸 **Before/After:** No visual changes, but screen readers will now announce "Select file: [filename]" and hovering over disabled directories will display a helpful tooltip.
♿ **Accessibility:** Added `aria-label` to provide context for screen readers. Added `title` to explain the disabled state of directory checkboxes.

---
*PR created automatically by Jules for task [14993217329955156139](https://jules.google.com/task/14993217329955156139) started by @arumes31*