### PR TITLE
⚡ Bolt: Optimize GetHostStats queue loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+## 2025-05-25 - Avoid O(N*M) polling in critical sections
+**Learning:** Frequent polling of `GetHostStats()` containing nested loops (`O(Hosts * Tasks * 2)`) within an `RLock` can lead to read-lock contention, especially since it's queried every second by the frontend.
+**Action:** When aggregating stats in polling endpoints that hold locks, minimize complexity. Pre-aggregate or use a single `O(Tasks)` pass with hash maps.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,48 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	// ⚡ Bolt: Pre-aggregate task data per host in a single O(N) pass over qm.tasks.
+	// Reduces O(Hosts * Tasks * 2) inside a frequent read-lock to O(Hosts + Tasks).
+	type hostAgg struct {
+		hasActiveTasks bool
+		activeCount    int
+		totalSpeedBps  float64
+	}
+	aggs := make(map[string]*hostAgg)
+
+	for _, t := range qm.tasks {
+		agg, exists := aggs[t.Config.Host]
+		if !exists {
+			agg = &hostAgg{}
+			aggs[t.Config.Host] = agg
 		}
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			agg.hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				agg.activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						agg.totalSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
 
+	var stats []models.HostStats
+	for host, limiter := range qm.limiters {
+		agg, exists := aggs[host]
+		if exists && agg.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    agg.activeCount,
+				TotalSpeedKBps: agg.totalSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 What: Optimized the `GetHostStats()` endpoint logic by pre-aggregating active tasks and overall host speeds using a hash map, transforming an O(Hosts * Tasks * 2) complexity to a linear O(Tasks + Hosts) single-pass operation inside a highly-polled RLock block.
🎯 Why: `/api/stats` is queried every second by the frontend polling mechanism. Continuously running an O(N*M) calculation with nested loops on a single `RLock` read scope blocks pending `mu.Lock()` events (like writes from active running queue workers) and slows overall processing.
📊 Impact: CPU execution inside the RLock block for `GetHostStats()` scales better and eliminates redundant inner iterations.
🔬 Measurement: Verify test suite execution with `go test ./...` passes to confirm stats data extraction behaves identically to the nested loop code before it.

---
*PR created automatically by Jules for task [16291686661100936397](https://jules.google.com/task/16291686661100936397) started by @arumes31*