### PR TITLE
🎨 Palette: [UX improvement] Add aria-sort attributes for accessible table sorting

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2024-05-02 - Accessible Sortable Table Headers
+**Learning:** Found table columns providing visual cue for sorting but missing screen-reader indication of which columns were sortable, and which direction they're currently sorted.
+**Action:** Always verify `aria-sort` accompanies sorting directional carets for a fully accessible UI. Ensure dynamic sorting JS logic includes setting the aria attribute (e.g. `aria-sort="ascending"`, `descending`, `none`) accordingly.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -406,10 +406,12 @@ document.addEventListener('DOMContentLoaded', () => {
         const table = document.getElementById(tableId);
         table.querySelectorAll('th.sortable').forEach(th => {
             th.classList.remove('sort-asc', 'sort-desc');
+            th.setAttribute('aria-sort', 'none');
             const arrow = th.querySelector('.sort-arrow');
             if (arrow) arrow.textContent = '\u25B2';
             if (th.dataset.sort === sortState.key) {
                 th.classList.add(sortState.dir === 'asc' ? 'sort-asc' : 'sort-desc');
+                th.setAttribute('aria-sort', sortState.dir === 'asc' ? 'ascending' : 'descending');
                 if (arrow) arrow.textContent = sortState.dir === 'asc' ? '\u25B2' : '\u25BC';
             }
         });

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -189,11 +189,11 @@
                                             <tr>
                                                 <th class="col-check"><input type="checkbox" id="select-all-checkbox" aria-label="Select all local files">
                                                 </th>
-                                                <th class="col-name sortable" data-sort="name">Name <span
+                                                <th class="col-name sortable" data-sort="name" aria-sort="none">Name <span
                                                         class="sort-arrow">▲</span></th>
-                                                <th class="col-size sortable" data-sort="size">Size <span
+                                                <th class="col-size sortable" data-sort="size" aria-sort="none">Size <span
                                                         class="sort-arrow">▲</span></th>
-                                                <th class="col-type sortable" data-sort="type">Type <span
+                                                <th class="col-type sortable" data-sort="type" aria-sort="none">Type <span
                                                         class="sort-arrow">▲</span></th>
                                             </tr>
                                         </thead>
@@ -232,11 +232,11 @@
                                     <table id="remote-file-table" class="file-table">
                                         <thead>
                                             <tr>
-                                                <th class="col-name sortable" data-sort="name">Name <span
+                                                <th class="col-name sortable" data-sort="name" aria-sort="none">Name <span
                                                         class="sort-arrow">▲</span></th>
-                                                <th class="col-size sortable" data-sort="size">Size <span
+                                                <th class="col-size sortable" data-sort="size" aria-sort="none">Size <span
                                                         class="sort-arrow">▲</span></th>
-                                                <th class="col-type sortable" data-sort="type">Type <span
+                                                <th class="col-type sortable" data-sort="type" aria-sort="none">Type <span
                                                         class="sort-arrow">▲</span></th>
                                             </tr>
                                         </thead>


### PR DESCRIPTION
💡 What: Added the standard `aria-sort` attribute to all sortable table column headers in the UI, defaulting to `none` and toggling dynamically to `ascending` or `descending` depending on sorting state.

🎯 Why: To make the file explorer grids fully accessible. Screen reader users need to be able to identify which columns are sortable and the current sort direction. Prior to this, sorting cues were purely visual (e.g. `▲` carets).

📸 Before/After: Visual presentation is unmodified, purely an a11y enhancement. Tested explicitly to guarantee visual consistency.

♿ Accessibility: Ensures WCAG standard compliant sorting headers with accurate `aria-sort` readings.

---
*PR created automatically by Jules for task [16163850052857304023](https://jules.google.com/task/16163850052857304023) started by @arumes31*