### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting to login endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,8 @@
 **Prevention:**
 1. Used a robust `escapeHTML` helper function in `ui/static/app.js` to encode HTML entities (`&`, `<`, `>`, `"`, `'`) before using them in DOM elements constructed via `innerHTML`.
 2. Replaced the standard password string comparison (`!=`) in `internal/api/server.go` with `subtle.ConstantTimeCompare` from the `crypto/subtle` package to ensure the comparison time is independent of the input contents.
+
+## 2024-05-18 - Brute-Force Prevention via Rate Limiting
+**Vulnerability:** The `/api/login` endpoint lacked any rate limiting. An attacker could rapidly test passwords, making the application susceptible to brute-force credential stuffing.
+**Learning:** Adding rate limits is a multi-step process. Using an unbounded IP map as a store will lead to memory exhaustion attacks (DoS), and 5 attempts per second is too high.
+**Prevention:** Added an IP-based rate limiter to the `/api/login` route. Configured it to allow 5 attempts per minute with a burst of 5. Added a background cleanup routine that prunes inactive limiters after 10 minutes.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	pathpkg "path"
@@ -15,6 +16,7 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/base64"
+	"golang.org/x/time/rate"
 	"sync"
 	"uplarr/internal/logger"
 	"uplarr/internal/models"
@@ -117,6 +119,41 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 
 	mux := http.NewServeMux()
 
+	// IP-based rate limiter for login to prevent brute force attacks
+	type visitor struct {
+		limiter  *rate.Limiter
+		lastSeen time.Time
+	}
+	var loginLimiters = make(map[string]*visitor)
+	var loginLimitersMu sync.Mutex
+
+	// Cleanup routine to prevent memory leaks from unbounded map growth
+	go func() {
+		for {
+			time.Sleep(10 * time.Minute)
+			loginLimitersMu.Lock()
+			for ip, v := range loginLimiters {
+				if time.Since(v.lastSeen) > 10*time.Minute {
+					delete(loginLimiters, ip)
+				}
+			}
+			loginLimitersMu.Unlock()
+		}
+	}()
+
+	getLoginLimiter := func(ip string) *rate.Limiter {
+		loginLimitersMu.Lock()
+		defer loginLimitersMu.Unlock()
+		if v, exists := loginLimiters[ip]; exists {
+			v.lastSeen = time.Now()
+			return v.limiter
+		}
+		// Allow 5 login attempts per minute per IP, with a burst of 5
+		limiter := rate.NewLimiter(rate.Every(time.Minute/5), 5)
+		loginLimiters[ip] = &visitor{limiter: limiter, lastSeen: time.Now()}
+		return limiter
+	}
+
 	withAuth := func(next http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			if config.AuthPassword == "" {
@@ -154,6 +191,15 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 	}
 
 	mux.HandleFunc("/api/login", func(w http.ResponseWriter, r *http.Request) {
+		ip, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			ip = r.RemoteAddr
+		}
+		if !getLoginLimiter(ip).Allow() {
+			http.Error(w, "Too many login attempts", http.StatusTooManyRequests)
+			return
+		}
+
 		if config.AuthPassword == "" {
 			w.WriteHeader(http.StatusOK)
 			return


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `/api/login` endpoint lacked any rate limiting. An attacker could rapidly test passwords, making the application susceptible to brute-force credential stuffing.
🎯 Impact: Attackers can continuously guess the `AUTH_PASSWORD` until they gain full access to the file system and SFTP.
🔧 Fix: Implemented an IP-based rate limiter using `golang.org/x/time/rate`. Limits login attempts to 5 per minute per IP. Added a background cleanup routine to purge inactive IP limiters to prevent unbounded memory map growth (DoS).
✅ Verification: Ran unit tests. Built the binary. Verified that the map is cleared after the duration limit.

---
*PR created automatically by Jules for task [11764024830095438539](https://jules.google.com/task/11764024830095438539) started by @arumes31*