### PR TITLE
🎨 Palette: Add context-aware ARIA labels to dynamic elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2024-05-04 - Dynamic Element Accessibility
+**Learning:** Dynamically generated tables (like file lists and queues) often contain identical generic text for interactive elements (e.g., "Pause" or empty checkboxes), causing confusion for screen reader users as they navigate rows without context.
+**Action:** When generating rows dynamically in Vanilla JS, always inject context-specific data from the row object (like `file.name` or `task.file_name`) directly into the `aria-label` attribute of its interactive elements to ensure individual element distinctness.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,6 +976,7 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
             if (file.is_dir) cb.disabled = true;
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
@@ -1400,6 +1401,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
                     controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.setAttribute('aria-label', `${task.status === 'Paused' ? 'Resume' : 'Pause'} transfer for ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1407,6 +1409,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', `Retry transfer for ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1414,6 +1417,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', `Remove transfer for ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
**💡 What:** Added context-aware `aria-label` attributes to dynamically created checkboxes and buttons in `ui/static/app.js`.
**🎯 Why:** Screen reader users needed more context for repetitive table elements. Without it, they would hear multiple identical buttons ("Pause", "Retry") or empty checkboxes without knowing which file they affected.
**📸 Before/After:** (No visual changes, purely semantic DOM updates).
**♿ Accessibility:** Greatly improves screen reader navigation in the local files and queue tables.

---
*PR created automatically by Jules for task [1054300641443883320](https://jules.google.com/task/1054300641443883320) started by @arumes31*