### PR TITLE
⚡ Bolt: Optimize GetHostStats to O(T+H) to reduce lock contention

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2025-05-25 - Avoid O(N*M) loops inside read/write mutexes
+**Learning:** O(N*M) nested loops (e.g., iterating through `tasks` for every `host`) inside a `RWMutex.RLock()` block causes significant lock contention. This can block worker threads and delay other endpoints like `/api/stats` which relies on `GetHostStats`.
+**Action:** When aggregating stats from multiple collections inside a locked region, always try to pre-aggregate data in a single pass (O(N+M)) using a map or hash table to drastically minimize time spent holding the lock.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,49 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	// ⚡ Bolt Optimization: Pre-aggregate task stats in a single pass O(T)
+	// instead of iterating all tasks for every limiter O(H * T)
+	type hostAgg struct {
+		hasActiveTasks bool
+		activeCount    int
+		hostSpeedBps   float64
+	}
+	agg := make(map[string]*hostAgg)
+
+	for _, t := range qm.tasks {
+		h := t.Config.Host
+		if agg[h] == nil {
+			agg[h] = &hostAgg{}
 		}
+		a := agg[h]
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			a.hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				a.activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						a.hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
+
+	var stats []models.HostStats
+	for host, limiter := range qm.limiters {
+		a := agg[host]
+		if a != nil && a.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    a.activeCount,
+				TotalSpeedKBps: a.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 **What**: Refactored the `GetHostStats` loop structure in `internal/queue/manager.go` to pre-aggregate active task statistics by host into a hash map in a single pass O(T) before looking up `limiter` statistics O(H).

🎯 **Why**: The original implementation iterated over all tasks `qm.tasks` for every element in `qm.limiters` inside a `RWMutex.RLock()`. In a scenario with a large queue (many tasks) and multiple host configurations, this nested O(H * T) loop holds the read lock longer than necessary, causing significant lock contention. This can block worker threads that need to acquire the lock to change task states, and severely delay HTTP responses on the frequently polled `/api/stats` endpoint.

📊 **Impact**: Reduces time-complexity inside the lock critical section from O(H * T) to O(H + T). Under heavy load (e.g., thousands of queued tasks across several servers), this will dramatically lower lock contention and keep the API/SSE endpoints extremely responsive.

🔬 **Measurement**: 
1. Build the application: `go build -o uplarr ./cmd/uplarr`
2. Run the application and queue a massive number of files.
3. Rapidly poll the `/api/stats` endpoint or observe the application performance when `GetHostStats` is invoked repeatedly via the web GUI's SSE connection. No jank or lock waits should occur.

---
*PR created automatically by Jules for task [13045588992882145748](https://jules.google.com/task/13045588992882145748) started by @arumes31*