### PR TITLE
🎨 Palette: Add contextual ARIA labels and tooltips to file selection checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2025-02-18 - Contextual Accessibility in Dynamic Tables
+**Learning:** Screen readers struggle with generic inputs (like checkboxes) inside dynamic data tables unless explicitly labeled. Additionally, disabling interactive elements (like directory checkboxes) without visual explanation creates a confusing experience.
+**Action:** Always add contextual `aria-label`s to dynamically generated table inputs (e.g., `Select file [name]`) and provide `title` tooltips for explicitly disabled elements so users understand why interaction is blocked.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.is_dir ? 'directory' : 'file'} ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = "Directories cannot be selected directly";
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 What: Added `aria-label` to file selection checkboxes and `title` tooltips for disabled directory checkboxes.
🎯 Why: Enhances screen reader accessibility by providing context for checkboxes in dynamic data tables, and clarifies to sighted users why directory selection is disabled.
♿ Accessibility: Improves keyboard and screen reader navigation within the file explorer.

---
*PR created automatically by Jules for task [7057540101550354821](https://jules.google.com/task/7057540101550354821) started by @arumes31*