### PR TITLE
⚡ Bolt: Optimize GetHostStats to O(T+H) to reduce lock contention

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2025-05-26 - Optimize aggregation loops inside Mutexes
+**Learning:** Performing nested loops over maps and slices ($O(H \times T)$ complexity) inside a read/write mutex blocks other operations and slows down frequently polled API endpoints.
+**Action:** When aggregating data inside a lock, iterate over slices once (e.g., $O(T)$) to populate intermediate maps, reducing total complexity to $O(H + T)$ and minimizing lock contention.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,41 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
-		}
+	// Bolt: O(T+H) optimization to minimize lock contention.
+	// We do a single pass over tasks to aggregate metrics per host.
+	activeCounts := make(map[string]int)
+	hostSpeedsBps := make(map[string]float64)
+	hasActiveTasks := make(map[string]bool)
+	now := time.Now()
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
-					elapsed := time.Since(*t.StartedAt).Seconds()
+	for _, t := range qm.tasks {
+		host := t.Config.Host
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			hasActiveTasks[host] = true
+			if t.Status == models.TaskRunning {
+				activeCounts[host]++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
+					elapsed := now.Sub(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						hostSpeedsBps[host] += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
+
+	var stats []models.HostStats
+	for host, limiter := range qm.limiters {
+		if hasActiveTasks[host] {
+			curr, max, lat := limiter.GetStats()
 
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    activeCounts[host],
+				TotalSpeedKBps: hostSpeedsBps[host] / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 What: Refactored `GetHostStats` to use a single pass over tasks to aggregate metrics into maps, replacing a nested loop. Also pulled `time.Now()` out of the loop.
🎯 Why: The previous implementation performed an $O(H \times T)$ nested loop while holding `qm.mu.RLock()`. In scenarios with many tasks and hosts, this caused significant lock contention, degrading performance on the `/api/stats` endpoint which is polled frequently by the UI.
📊 Impact: Reduces time complexity within the read-lock critical section from $O(H \times T)$ to $O(H + T)$, significantly reducing CPU overhead and lock hold times.
🔬 Measurement: Verify by running tests or benchmarking the `/api/stats` endpoint under a large number of simulated hosts and concurrent queue tasks.

---
*PR created automatically by Jules for task [4989250808144116173](https://jules.google.com/task/4989250808144116173) started by @arumes31*