### PR TITLE
🎨 Palette: Enhance keyboard accessibility for custom interactive elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2024-05-18 - Keyboard accessibility for custom interactive elements
+**Learning:** In Vanilla JS applications, interactive elements that behave like links or buttons (like custom file browser breadcrumbs, custom tree sidebars, and clickable table rows) often lack keyboard accessibility by default. Screen reader and keyboard-only users cannot access them.
+**Action:** When creating custom interactive DOM elements via JS (e.g., dynamically rendering clickable segments), always add `role="button"`, `tabIndex=0`, and listen for both `click` and `keydown` (`Enter` or `Space`) events. Pair with a visible `:focus-visible` CSS outline to ensure visual feedback during keyboard navigation.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -230,7 +230,16 @@ document.addEventListener('DOMContentLoaded', () => {
         rootIcon.className = 'breadcrumb-segment root';
         rootIcon.textContent = '/';
         rootIcon.title = 'Go to root';
-        rootIcon.addEventListener('click', () => isRemote ? fetchRemoteFiles('/') : fetchFiles(''));
+        rootIcon.setAttribute('role', 'button');
+        rootIcon.tabIndex = 0;
+        const rootAction = () => isRemote ? fetchRemoteFiles('/') : fetchFiles('');
+        rootIcon.addEventListener('click', rootAction);
+        rootIcon.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                rootAction();
+            }
+        });
         container.appendChild(rootIcon);
 
         const cleanPath = path.replace(/^[\\/]+|[\\/]+$/g, '');
@@ -250,7 +259,16 @@ document.addEventListener('DOMContentLoaded', () => {
             segment.className = 'breadcrumb-segment';
             segment.textContent = part;
             segment.title = `Jump to ${part}`;
-            segment.addEventListener('click', () => isRemote ? fetchRemoteFiles(currentAcc) : fetchFiles(currentAcc));
+            segment.setAttribute('role', 'button');
+            segment.tabIndex = 0;
+            const segmentAction = () => isRemote ? fetchRemoteFiles(currentAcc) : fetchFiles(currentAcc);
+            segment.addEventListener('click', segmentAction);
+            segment.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    segmentAction();
+                }
+            });
             container.appendChild(segment);
         });
     };
@@ -810,7 +828,16 @@ document.addEventListener('DOMContentLoaded', () => {
                 <span>${escapeHTML(name)}</span>
             `;
             item.title = p;
-            item.onclick = () => isRemote ? fetchRemoteFiles(p) : fetchFiles(p);
+            item.setAttribute('role', 'button');
+            item.tabIndex = 0;
+            const itemAction = () => isRemote ? fetchRemoteFiles(p) : fetchFiles(p);
+            item.onclick = itemAction;
+            item.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    itemAction();
+                }
+            });
             container.appendChild(item);
         });
     };
@@ -953,8 +980,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (file.is_dir) {
                 row.className = 'clickable-row folder-row';
+                row.tabIndex = 0;
+                const rowAction = () => fetchFiles(fullRelPath);
                 row.addEventListener('click', (e) => {
-                    if (e.target.type !== 'checkbox') fetchFiles(fullRelPath);
+                    if (e.target.type !== 'checkbox') rowAction();
+                });
+                row.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        if (e.target.type !== 'checkbox') {
+                            e.preventDefault();
+                            rowAction();
+                        }
+                    }
                 });
             } else {
                 row.draggable = true;
@@ -1131,9 +1168,17 @@ document.addEventListener('DOMContentLoaded', () => {
             const row = document.createElement('tr');
             if (file.is_dir) {
                 row.className = 'clickable-row folder-row';
-                row.addEventListener('click', () => {
+                row.tabIndex = 0;
+                const rowAction = () => {
                     const newPath = remoteCurrentPath.endsWith('/') ? remoteCurrentPath + file.name : remoteCurrentPath + '/' + file.name;
                     fetchRemoteFiles(newPath);
+                };
+                row.addEventListener('click', rowAction);
+                row.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        rowAction();
+                    }
                 });
             }
 

--- a/ui/static/style.css
+++ b/ui/static/style.css
@@ -729,6 +729,11 @@ a:focus-visible,
     outline-offset: 2px;
 }
 
+.clickable-row:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: -2px; /* Ensure outline is visible inside table rows */
+}
+
 /* Buttons */
 button {
     font-family: var(--font-main);


### PR DESCRIPTION
## 💡 What: The UX enhancement added
Added full keyboard navigation support for custom interactive elements within the UI. Specifically, breadcrumb paths, the sidebar folder tree, and clickable directory table rows in both the local and remote file browsers can now be focused using `Tab` and activated using `Enter` or `Space`.

## 🎯 Why: The user problem it solves
Because these elements are implemented as custom tags (e.g. `div`, `span`, `tr`) instead of native `<button>` or `<a>` elements, they were inaccessible to screen readers and users navigating solely via keyboard. This addresses a significant accessibility gap where power users could not browse folders without a mouse.

## 📸 Before/After: Screenshots
See frontend verification output from Playwright testing verifying focus-ring visibility on breadcrumbs, tree items, and rows.

## ♿ Accessibility: Any a11y improvements made
- Added `role="button"` and `tabIndex="0"` semantics to custom interactables
- Added `keydown` listeners handling Enter/Space key triggers uniformly alongside `click` events
- Added specific `outline-offset: -2px` in `.clickable-row:focus-visible` to ensure the focus ring respects the table constraints without changing global aesthetics

---
*PR created automatically by Jules for task [3779636371627091353](https://jules.google.com/task/3779636371627091353) started by @arumes31*