### PR TITLE
🎨 Palette: Add keyboard accessibility to folder rows

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2024-05-23 - Keyboard accessibility for interactive container rows
+**Learning:** When making container elements (like table rows with `.clickable-row`) accessible via keyboard navigation by adding `tabindex="0"` and a `keydown` listener, failing to check the event target can cause child inputs (like checkboxes) to trigger the container's action unexpectedly when the user tries to interact with the child using the keyboard.
+**Action:** Always verify `e.target.type` (e.g., `e.target.type !== 'checkbox'`) in the container's keyboard event listener to ensure nested interactive elements retain their default behavior without triggering the container's action.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -953,8 +953,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (file.is_dir) {
                 row.className = 'clickable-row folder-row';
+                row.tabIndex = 0;
                 row.addEventListener('click', (e) => {
                     if (e.target.type !== 'checkbox') fetchFiles(fullRelPath);
+                });
+                row.addEventListener('keydown', (e) => {
+                    if ((e.key === 'Enter' || e.key === ' ') && e.target.type !== 'checkbox') {
+                        e.preventDefault();
+                        fetchFiles(fullRelPath);
+                    }
                 });
             } else {
                 row.draggable = true;
@@ -1131,9 +1138,17 @@ document.addEventListener('DOMContentLoaded', () => {
             const row = document.createElement('tr');
             if (file.is_dir) {
                 row.className = 'clickable-row folder-row';
+                row.tabIndex = 0;
                 row.addEventListener('click', () => {
                     const newPath = remoteCurrentPath.endsWith('/') ? remoteCurrentPath + file.name : remoteCurrentPath + '/' + file.name;
                     fetchRemoteFiles(newPath);
+                });
+                row.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        const newPath = remoteCurrentPath.endsWith('/') ? remoteCurrentPath + file.name : remoteCurrentPath + '/' + file.name;
+                        fetchRemoteFiles(newPath);
+                    }
                 });
             }
 


### PR DESCRIPTION
💡 **What**: Added `tabindex="0"` to `.clickable-row` elements and wired up a `keydown` event listener to trigger row clicks on 'Enter' or 'Space'.
🎯 **Why**: Users relying on keyboard navigation were previously unable to browse into folders, as the rows were only accessible via mouse clicks.
📸 **Before/After**: Visually unchanged, but elements now show focus states and react to keyboard input.
♿ **Accessibility**: Significant improvement for keyboard and screen-reader users navigating the primary file browsing interfaces.

---
*PR created automatically by Jules for task [830740357279206327](https://jules.google.com/task/830740357279206327) started by @arumes31*