### PR TITLE
⚡ Bolt: O(T+H) optimization in GetHostStats

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2026-05-08 - O(N^2) lock contention in QueueManager GetHostStats
+**Learning:** O(T*H) nested loop algorithm executed inside QueueManager's read lock. This blocked the lock and resulted in a noticeable delay and queue processing contention on the frequently polled endpoint `/api/stats`.
+**Action:** When working on methods running under read/write Mutex scope in high-poll loops, ensure algorithm complexity is minimized (e.g. use mapping/aggregation).

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,53 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	type hostAgg struct {
+		activeTasks  int
+		hostSpeedBps float64
+		hasActive    bool
+	}
+	agg := make(map[string]*hostAgg)
+
+	// O(T) pass: aggregate task metrics by host
+	for _, t := range qm.tasks {
+		h := t.Config.Host
+		if _, exists := qm.limiters[h]; !exists {
+			continue // Only track hosts we have limiters for
 		}
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
+		a, ok := agg[h]
+		if !ok {
+			a = &hostAgg{}
+			agg[h] = a
+		}
 
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			a.hasActive = true
+			if t.Status == models.TaskRunning {
+				a.activeTasks++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						a.hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
 
+	var stats []models.HostStats
+	// O(H) pass: build stats for hosts with active tasks
+	for host, limiter := range qm.limiters {
+		a, ok := agg[host]
+		if ok && a.hasActive {
+			curr, max, lat := limiter.GetStats()
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    a.activeTasks,
+				TotalSpeedKBps: a.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 What: Replaced nested $O(T \times H)$ loops over `qm.tasks` and `qm.limiters` inside `GetHostStats()` with two sequential $O(T)$ and $O(H)$ loops using a temporary aggregation map.

🎯 Why: This code runs under a read lock (`qm.mu.RLock()`) on a highly polled API endpoint (`/api/stats`). With many active tasks and hosts, an $O(T \times H)$ loop creates unnecessary read-lock contention, which delays write locks and delays task scheduling in the queue manager.

📊 Impact: Reduces time complexity significantly from $O(T \times H)$ to $O(T+H)$, practically eliminating CPU waste during rapid polling and minimizing mutex lock contention duration.

🔬 Measurement: Run tests using `go test ./internal/queue -v` and observe execution time.

---
*PR created automatically by Jules for task [15391254228390271353](https://jules.google.com/task/15391254228390271353) started by @arumes31*