### PR TITLE
🎨 Palette: Add keyboard navigation support for folder rows

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2026-05-09 - Accessible interactive rows with internal inputs
+**Learning:** Found that when adding keyboard accessibility (`keydown` for `Enter`/`Space`) to a custom interactive element that wraps other focusable inputs (like a table row wrapping a checkbox), normal keyboard interactions with the child input can unintentionally trigger the parent's event listener.
+**Action:** When adding keydown event listeners to custom interactive elements containing inputs, explicitly ignore events originating from child inputs (e.g., `if (e.target.type !== 'checkbox')`) to prevent overriding their default behavior during keyboard navigation.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -953,8 +953,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (file.is_dir) {
                 row.className = 'clickable-row folder-row';
+                row.tabIndex = 0;
                 row.addEventListener('click', (e) => {
                     if (e.target.type !== 'checkbox') fetchFiles(fullRelPath);
+                });
+                row.addEventListener('keydown', (e) => {
+                    if (e.target.type !== 'checkbox' && (e.key === 'Enter' || e.key === ' ')) {
+                        e.preventDefault();
+                        fetchFiles(fullRelPath);
+                    }
                 });
             } else {
                 row.draggable = true;
@@ -1131,9 +1138,17 @@ document.addEventListener('DOMContentLoaded', () => {
             const row = document.createElement('tr');
             if (file.is_dir) {
                 row.className = 'clickable-row folder-row';
+                row.tabIndex = 0;
                 row.addEventListener('click', () => {
                     const newPath = remoteCurrentPath.endsWith('/') ? remoteCurrentPath + file.name : remoteCurrentPath + '/' + file.name;
                     fetchRemoteFiles(newPath);
+                });
+                row.addEventListener('keydown', (e) => {
+                    if (e.target.type !== 'checkbox' && (e.key === 'Enter' || e.key === ' ')) {
+                        e.preventDefault();
+                        const newPath = remoteCurrentPath.endsWith('/') ? remoteCurrentPath + file.name : remoteCurrentPath + '/' + file.name;
+                        fetchRemoteFiles(newPath);
+                    }
                 });
             }
 


### PR DESCRIPTION
💡 **What**: Added `tabIndex=0` and a `keydown` listener to the custom `clickable-row` folder rows in the local and remote file tables.
🎯 **Why**: Previously, folder rows could only be interacted with via mouse clicks. Keyboard users or screen reader users had no way to focus or trigger the "enter folder" action, making navigation difficult without a mouse.
📸 **Before/After**: See frontend verification screenshots showing visual focus states and successful traversal via keyboard input.
♿ **Accessibility**: Significant improvement for keyboard navigation. Includes preventative logic to stop row-level `Enter` or `Space` events from firing when the user's intent was to toggle the row's checkbox with the keyboard.

---
*PR created automatically by Jules for task [8794289452894260921](https://jules.google.com/task/8794289452894260921) started by @arumes31*