### PR TITLE
⚡ Bolt: Optimize GetHostStats to O(T+H)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+## 2025-05-25 - Avoid O(N*M) nested loops under RWMutex
+**Learning:** In the `GetHostStats` function, iterating over all tasks inside a loop over all hosts created an O(T*H) time complexity. Since this is executed under a read lock (`qm.mu.RLock()`), it prolongs lock duration, which can block write operations and cause contention, especially when polled frequently.
+**Action:** Always prefer O(N+M) aggregation using an intermediate map rather than nested loops when processing large collections, especially inside critical sections protected by a Mutex.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,48 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	// ⚡ Bolt: Use O(T+H) aggregation instead of O(T*H) nested loops to reduce Mutex contention
+	type hostAgg struct {
+		hasActiveTasks bool
+		activeCount    int
+		hostSpeedBps   float64
+	}
+	agg := make(map[string]*hostAgg)
+
+	for _, t := range qm.tasks {
+		host := t.Config.Host
+		if agg[host] == nil {
+			agg[host] = &hostAgg{}
 		}
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			agg[host].hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				agg[host].activeCount++
 
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						agg[host].hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
+
+	var stats []models.HostStats
+	for host, limiter := range qm.limiters {
+		hAgg := agg[host]
+		if hAgg != nil && hAgg.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    hAgg.activeCount,
+				TotalSpeedKBps: hAgg.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 What: Refactored `GetHostStats` in `internal/queue/manager.go` to use a map for aggregation, changing its time complexity from O(T*H) to O(T+H).
🎯 Why: `GetHostStats` holds a read lock (`qm.mu.RLock()`) over the task slice and limiter map. The original O(T*H) nested loop caused prolonged lock contention, especially since this is polled frequently by the UI.
📊 Impact: Reduces Mutex contention drastically by completing the stat collection in linear time.
🔬 Measurement: Run load tests simulating many tasks across several hosts to verify reduced API latency and CPU overhead on `/api/stats`.

---
*PR created automatically by Jules for task [16897632036889014810](https://jules.google.com/task/16897632036889014810) started by @arumes31*