### PR TITLE
🎨 Palette: Add ARIA labels and disabled state explanations to file checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,4 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2026-05-10 - Adding accessibility to file checkboxes\n**Learning:** Found that dynamically generated file checkboxes lacked screen reader labels and disabled state explanations for directories, reducing accessibility and clarity.\n**Action:** When dynamically generating checkboxes or interactive elements, always pair them with an `aria-label` containing contextual info (like file name) and add a `title` tooltip to explain disabled states.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = 'Directories cannot be selected';
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 **What:** Added `aria-label` to the dynamically generated file checkboxes, and a `title` tooltip to explain the disabled state for directories.
🎯 **Why:** To ensure screen readers have context for which file is being selected, and to give visual users clear feedback on why directory rows cannot be checked.
♿ **Accessibility:** Added proper screen reader labeling for the primary interactive element in the file list.
📸 **Before/After:** See the attached visual verification screenshots from the Playwright test.

---
*PR created automatically by Jules for task [793837099645048651](https://jules.google.com/task/793837099645048651) started by @arumes31*