### PR TITLE
🎨 Palette: Add aria-labels and titles to dynamically generated checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2024-05-18 - Added Checkbox ARIA Labels and Disabled Titles
+**Learning:** Dynamically generated input elements, specifically checkboxes in file lists, lack inherent context for screen readers if not paired with explicit labels. Additionally, disabled elements without explanation cause user confusion.
+**Action:** When dynamically generating checkboxes or form inputs in vanilla JS, always apply `aria-label` to provide context (e.g., "Select file.txt"). If an element must be disabled, provide a `title` attribute explaining why it is inactive.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = "Directories cannot be selected";
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
### 💡 What
Added `aria-label` attributes to dynamically generated file selection checkboxes.
Added `title` attributes (tooltips) to disabled directory checkboxes.

### 🎯 Why
Dynamically generated checkboxes in lists without associated `<label>` elements lack context for screen readers. Adding an `aria-label` provides this missing context. Furthermore, users may be confused why directory checkboxes are disabled; adding a `title` provides a native tooltip to explain the restriction.

### 📸 Before/After
Screen readers will now announce "Select [filename]" instead of just "checkbox". Hovering over a disabled directory checkbox will display a tooltip saying "Directories cannot be selected".

### ♿ Accessibility
Improved screen reader support for file selection.
Improved clarity for disabled state interactions.

---
*PR created automatically by Jules for task [11033984749833222603](https://jules.google.com/task/11033984749833222603) started by @arumes31*