### PR TITLE
⚡ Bolt: Optimize GetHostStats to O(T+H)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2025-05-25 - Optimize map aggregations under lock
+**Learning:** Nested loops iterating over $O(H)$ and $O(T)$ elements while holding a read-lock can create contention in frequently polled backend APIs (e.g., `/api/stats`). By taking a single pass over tasks to aggregate needed data into a temporary map, the complexity reduces from $O(H \times T)$ to $O(H + T)$.
+**Action:** When calculating statistics or filtering data under a mutex, especially in an API endpoint, prefer $O(N)$ single-pass map aggregations over nested loops to minimize lock hold duration and prevent blocking workers.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,54 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	// ⚡ Bolt: Optimize GetHostStats from O(T×H) to O(T+H)
+	// We aggregate active tasks and speeds in a single pass over tasks,
+	// rather than looping over tasks for every host in the limiters map.
+	// This minimizes the duration the read lock is held on this frequently polled endpoint.
+
+	type hostAgg struct {
+		hasActiveTasks bool
+		activeCount    int
+		totalSpeedBps  float64
+	}
+	agg := make(map[string]*hostAgg)
+
+	// Single pass over tasks to compute active counts and speeds
+	for _, t := range qm.tasks {
+		h := t.Config.Host
+		if _, ok := agg[h]; !ok {
+			agg[h] = &hostAgg{}
 		}
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			agg[h].hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				agg[h].activeCount++
 
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						agg[h].totalSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
+
+	var stats []models.HostStats
+	// Single pass over limiters to build final output
+	for host, limiter := range qm.limiters {
+		hostData, ok := agg[host]
+		if ok && hostData.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    hostData.activeCount,
+				TotalSpeedKBps: hostData.totalSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 **What:** Refactored `GetHostStats` in `QueueManager` to compute task aggregations via a single pass rather than looping through all tasks for each host.
🎯 **Why:** The previous nested loop resulted in $O(T \times H)$ time complexity while holding a read lock, creating potential lock contention on the frequently polled `/api/stats` endpoint.
📊 **Impact:** Reduces time complexity to $O(T + H)$, significantly minimizing lock hold duration and avoiding backend bottlenecks as task queues grow.
🔬 **Measurement:** Verify by load testing the `/api/stats` endpoint with a large number of active limiters and tasks; CPU utilization and lock wait times will be demonstrably lower.

---
*PR created automatically by Jules for task [7127528703642745282](https://jules.google.com/task/7127528703642745282) started by @arumes31*