### PR TITLE
🎨 Palette: Add accessible labels and disabled state tooltips to file checkboxes

### DIFF
--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = 'Directories cannot be selected';
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 **What:** 
Added an `aria-label` attribute to the dynamically generated file checkboxes in the file browser. Additionally, for disabled checkboxes (which represent directories that cannot be selected), added a `title` attribute explaining the reason.

🎯 **Why:** 
Previously, the checkboxes were generated without context, making it difficult for screen reader users to understand what they were selecting. Furthermore, when a directory checkbox was disabled, sighted users had no clear indication *why* it couldn't be interacted with. This change improves both accessibility and overall user experience by providing clear context and feedback.

📸 **Before/After:**
*(Visual changes are in the form of a native browser tooltip on hover and screen-reader accessible attributes, verified via Playwright screenshot and video during development).*

♿ **Accessibility:**
- Added `aria-label="Select [filename]"` to provide specific context to assistive technologies.
- Added a `title="Directories cannot be selected"` tooltip to disabled inputs to explain their inactive state.

---
*PR created automatically by Jules for task [6047679667935433924](https://jules.google.com/task/6047679667935433924) started by @arumes31*