### PR TITLE
⚡ Bolt: Replace O(n²) nested loop in GetHostStats with O(n) hash map aggregation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2025-05-25 - Avoiding O(N^2) loops inside Mutexes
+**Learning:** Performing nested loops to aggregate data inside an RWMutex block on a frequently polled endpoint creates unnecessary lock contention and stalls the background queue worker.
+**Action:** Always aim for O(N) linear time complexity for data aggregation under a lock. Use hash maps or single-pass aggregations instead of O(T*H) nested loops to minimize lock hold times.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,45 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	// ⚡ Bolt: Pre-aggregate task stats per host to avoid O(T*H) nested loops inside the read lock
+	type hostAggregation struct {
+		hasActiveTasks bool
+		activeCount    int
+		hostSpeedBps   float64
+	}
+	agg := make(map[string]*hostAggregation)
+
+	for _, t := range qm.tasks {
+		h := t.Config.Host
+		if _, ok := agg[h]; !ok {
+			agg[h] = &hostAggregation{}
 		}
-
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			agg[h].hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				agg[h].activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						agg[h].hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
 
+	var stats []models.HostStats
+	for host, limiter := range qm.limiters {
+		a, exists := agg[host]
+		if exists && a.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    a.activeCount,
+				TotalSpeedKBps: a.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 **What:** Replaced the $O(T \times H)$ nested loop in `QueueManager.GetHostStats` with an $O(T + H)$ implementation by doing a single pass over `qm.tasks` to pre-aggregate active task counts and speeds per host into a hash map, followed by a single pass over `qm.limiters` to construct the final stats.

🎯 **Why:** The previous nested loop executed inside a read-write lock (`qm.mu.RLock()`), iterating over all tasks ($T$) for every single host limiter ($H$). As the task queue or number of hosts grew, this lock was held for significantly longer durations. Because the frontend polls the `/api/stats` endpoint very frequently (e.g., every second), this excessive lock holding caused lock contention, effectively stalling the background worker that processes tasks and freezing the queue.

📊 **Impact:** Reduces time complexity of stat aggregation under lock from $O(T \times H)$ to $O(T + H)$. This minimizes the lock hold time, significantly reducing contention on a frequently polled endpoint and preventing queue processing stalls when dealing with large numbers of tasks and hosts.

🔬 **Measurement:** Verify by running the application with a large number of queued tasks across multiple distinct hosts. The `/api/stats` endpoint response time should remain consistently low, and the background queue processing should no longer stall or experience reduced throughput due to lock contention during stats polling.

---
*PR created automatically by Jules for task [13990087695996552730](https://jules.google.com/task/13990087695996552730) started by @arumes31*