### PR TITLE
🎨 Palette: Improve dynamic checkbox accessibility and disabled state context

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2026-05-13 - Context for Dynamically Generated Disabled Elements
+**Learning:** Discovered that dynamically generated disabled form elements (like checkboxes for directories in file lists) lack context, confusing users about why they cannot interact with them. In addition, dynamically generated checkboxes for files didn't have `aria-label` set, reducing accessibility for screen reader users.
+**Action:** Always add an `aria-label` to dynamically generated inputs. For disabled inputs, add a `title` attribute to explain why the element is disabled, improving clarity and UX without requiring additional UI changes.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = 'Directories cannot be selected for upload directly';
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 **What:** 
Added dynamic `aria-label` attributes to the dynamically generated file checkboxes in the frontend UI. Also added a `title` attribute (native tooltip) to disabled checkboxes that represent directories.

🎯 **Why:** 
Previously, dynamically generated checkboxes for files lacked an `aria-label`, meaning screen reader users would hear "checkbox" without the context of *which* file they were selecting. Additionally, directories cannot be selected directly (they are disabled), but this disabled state lacked a visual explanation. Adding a `title` provides a native, zero-dependency tooltip explaining why the interaction is not possible, preventing user confusion.

♿ **Accessibility:**
- Improved screen reader context for file selection by explicitly announcing the file name (`aria-label="Select [filename]"`).
- Clarified system status by explaining disabled states via the `title` attribute.

---
*PR created automatically by Jules for task [16106811577714836974](https://jules.google.com/task/16106811577714836974) started by @arumes31*