### PR TITLE
🎨 Palette: Enhance accessibility for dynamic file checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+
+## 2026-05-14 - Checkbox Accessibility in File Tables
+**Learning:** Dynamically generated inputs in table structures often miss contextual labels. Screen readers simply announce "checkbox" without the file name context. Similarly, disabling elements (like directory checkboxes) without explanation creates a confusing UX gap for both visual and non-visual users.
+**Action:** Always add dynamic `aria-label`s (e.g., "Select {filename}") to generated checkboxes. For disabled interactive elements, explicitly add a `title` or `aria-description` explaining the inactive state.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,8 +976,13 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
-            if (queuedFiles.has(fullRelPath)) cb.checked = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.setAttribute('title', 'Directories cannot be selected directly');
+            } else {
+                if (queuedFiles.has(fullRelPath)) cb.checked = true;
+            }
 
             cb.addEventListener('click', (e) => {
                 const allCheckboxes = Array.from(fileListBody.querySelectorAll('.file-checkbox:not(:disabled)'));


### PR DESCRIPTION
💡 **What:** 
Added `aria-label` attributes to dynamically generated file selection checkboxes in the local file table, and added explanatory `title` tooltips to disabled directory checkboxes.

🎯 **Why:** 
Previously, screen readers would simply announce "checkbox" for file selections without providing context of *which* file was being selected. Furthermore, users could see directory checkboxes were disabled, but had no immediate feedback as to *why* they couldn't be selected. This improves both non-visual accessibility and visual micro-UX.

📸 **Before/After:** 
A screenshot of the verified change is available in the run artifacts (`/home/jules/verification/checkbox_a11y.png`).

♿ **Accessibility:** 
- Explicit screen reader context for interactive table elements.
- Clearer visual tooltips explaining inactive UI states.

---
*PR created automatically by Jules for task [10942995134523526284](https://jules.google.com/task/10942995134523526284) started by @arumes31*