### PR TITLE
⚡ Bolt: Optimize GetHostStats from O(T*H) to O(T+H)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2025-05-26 - Optimize Polled Endpoint Aggregations
+**Learning:** Nested loops ($O(T \times H)$) inside a read/write mutex for data aggregation causes severe lock contention, especially on frequently polled API endpoints like `/api/stats` when task and host counts are large.
+**Action:** Replace nested loops inside locked critical sections with separated $O(N)$ iterations (e.g., aggregating tasks into a map first, then iterating hosts), bringing complexity down to $O(T+H)$ and minimizing time spent holding the lock.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,48 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
+	type hostAgg struct {
+		hasActiveTasks bool
+		activeCount    int
+		hostSpeedBps   float64
+	}
+
+	// O(T) pass over tasks to aggregate metrics per host
+	agg := make(map[string]*hostAgg)
+	for _, t := range qm.tasks {
+		h := t.Config.Host
+		if agg[h] == nil {
+			agg[h] = &hostAgg{}
+		}
+
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			agg[h].hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				agg[h].activeCount++
 			}
 		}
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
-					elapsed := time.Since(*t.StartedAt).Seconds()
-					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
-					}
-				}
+		if t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+			elapsed := time.Since(*t.StartedAt).Seconds()
+			if elapsed > 0 {
+				agg[h].hostSpeedBps += float64(t.BytesUploaded) / elapsed
 			}
+		}
+	}
 
+	var stats []models.HostStats
+	// O(H) pass over limiters
+	for host, limiter := range qm.limiters {
+		a := agg[host]
+		if a != nil && a.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    a.activeCount,
+				TotalSpeedKBps: a.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 **What:** 
Replaced nested loops inside `QueueManager.GetHostStats` with an aggregated data structure strategy. Instead of looping over all tasks for every host in the system, we now loop over the tasks once to pre-aggregate stats into a map, and loop over the hosts once to build the final response payload.

🎯 **Why:** 
The `GetHostStats` function acquires an `RLock` on the QueueManager's mutex while iterating. When there are high counts for tasks ($T$) and tracked limiters/hosts ($H$), the original nested loop structure resulted in an $O(T \times H)$ complexity lock duration. Because this endpoint is polled rapidly by clients, the read lock contention could starve other API calls and backend worker updates.

📊 **Impact:** 
Algorithmic time complexity reduced from $O(T \times H)$ to $O(T + H)$ when calculating stats. Reduces CPU cycles spent inside a locked critical section and scales significantly better as task count increases, preventing RWMutex contention.

🔬 **Measurement:** 
Unit tests pass. To verify scaling improvements, inject 100 limiters and 10,000 tasks and hit the `/api/stats` endpoint while running `go test -bench` inside `internal/queue`.

---
*PR created automatically by Jules for task [14092729723999396904](https://jules.google.com/task/14092729723999396904) started by @arumes31*