### PR TITLE
🎨 Palette: Add context to dynamic lists and disabled states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ test_data/
 /queue
 .Jules/
 .Jules
+# Queue state file
+config/.queue_state.json

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2026-05-15 - Add context to dynamic lists and disabled states
+**Learning:** Found that dynamically generated components like item action buttons in a list (e.g. Pause, Retry, Remove) lacked clear context for screen-reader users, and disabled directory checkboxes did not offer a visible explanation for being unselectable.
+**Action:** Always add `aria-label` to list items components (identifying the specific item they control) and assign `title` attributes explaining why inputs are disabled natively.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = 'Directories cannot be selected directly';
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {
@@ -1399,7 +1403,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (task.status === 'Pending' || task.status === 'Paused') {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
-                    controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    const actionName = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.textContent = actionName;
+                    controlBtn.setAttribute('aria-label', `${actionName} task for ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1407,6 +1413,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', `Retry task for ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1414,6 +1421,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', `Remove task for ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
### 💡 What
Added `aria-label`s to dynamically generated elements (checkboxes and queue action buttons) to provide proper context for screen readers. Added a `title` tooltip to directory checkboxes explaining why they are disabled. Appended `.gitignore` to prevent tracking of `config/.queue_state.json`.

### 🎯 Why
Screen reader users previously lacked context when interacting with dynamic lists, only hearing generic labels like "checkbox" or "Pause" without knowing which file it applied to. Explaining *why* an element is disabled (like a directory) improves overall usability and prevents user frustration. 

### ♿ Accessibility
- ARIA context added to local file list items.
- ARIA context added to queue task buttons.
- Tooltips added for explicitly communicating unselectable native form states.

---
*PR created automatically by Jules for task [16295895038400911499](https://jules.google.com/task/16295895038400911499) started by @arumes31*