### PR TITLE
⚡ Bolt: Optimize GetHostStats to O(T+H)

### DIFF
--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,47 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
+	// Performance optimization: O(T+H) map aggregation
+	// Avoids O(T * H) nested loop under RWMutex to prevent lock contention
+	type hostAgg struct {
+		hasActiveTasks bool
+		activeCount    int
+		hostSpeedBps   float64
+	}
+	agg := make(map[string]*hostAgg)
+
+	for _, t := range qm.tasks {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			h, ok := agg[t.Config.Host]
+			if !ok {
+				h = &hostAgg{}
+				agg[t.Config.Host] = h
 			}
-		}
-
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+			h.hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				h.activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						h.hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
 
+	var stats []models.HostStats
+	for host, limiter := range qm.limiters {
+		h, ok := agg[host]
+		if ok && h.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    h.activeCount,
+				TotalSpeedKBps: h.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 **What:** Refactored `QueueManager.GetHostStats()` to use an $O(T+H)$ map aggregation approach instead of nested $O(T \times H)$ loops.
🎯 **Why:** To prevent long RWMutex hold times and reduce CPU consumption during frequent queue stat polling, making the backend more scalable.
📊 **Impact:** Reduces lock contention on `qm.mu`, minimizing latency spikes for all API endpoints that read queue data.
🔬 **Measurement:** Verify by running benchmarks on `/api/stats` endpoint with high concurrent load.

---
*PR created automatically by Jules for task [17803040943222153361](https://jules.google.com/task/17803040943222153361) started by @arumes31*