### PR TITLE
🎨 Palette: Added ARIA labels and title tooltips to file list checkboxes

### DIFF
--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = 'Directories cannot be selected';
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 What: Added dynamic `aria-label`s to dynamically generated file checkboxes in the frontend UI, and added explicit `title` attributes to disabled checkboxes (directories).
🎯 Why: Without these attributes, screen readers only see a generic "checkbox" without context of which file it selects. The disabled state also lacked context for sighted users, who now get a native tooltip explaining why the element cannot be interacted with.
♿ Accessibility: Improves screen reader context and disabled element clarity.

---
*PR created automatically by Jules for task [11923378860499180444](https://jules.google.com/task/11923378860499180444) started by @arumes31*