### PR TITLE
🎨 Palette: Add accessibility labels to dynamic checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2026-05-17 - Added Accessibility Labels to Dynamically Generated Inputs
+**Learning:** Found that when dynamically creating `<input type="checkbox">` elements via JavaScript (e.g., in `app.js`'s `renderLocalFiles`), they lacked `aria-label`s, leaving screen reader users without context about which file the checkbox selects. Additionally, checkboxes disabled for directories lacked explanation.
+**Action:** When dynamically generating form elements, ensure accessibility and clear UX by adding `aria-label` attributes for screen reader context and `title` attributes on disabled elements to explicitly explain why they are inactive.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = 'Directories cannot be selected directly';
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 What: Added `aria-label` to the file selection checkboxes generated in `app.js`, and added a `title` tooltip to explain why directory checkboxes are disabled.
🎯 Why: Without an `aria-label`, screen readers have no context about which file a checkbox corresponds to. Additionally, users were given no explanation as to why directory checkboxes were unclickable.
♿ Accessibility: Improves screen reader navigation and clarifies the UI's inactive state for directories.

---
*PR created automatically by Jules for task [13918521124239469064](https://jules.google.com/task/13918521124239469064) started by @arumes31*