### PR TITLE
⚡ Bolt: Optimize GetHostStats complexity to O(T+H)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2026-05-17 - Optimize GetHostStats to O(T+H)
+**Learning:** The nested loop O(T*H) inside the frequently-called `GetHostStats` endpoint blocks the mutex `qm.mu.RLock()` longer than necessary as the queue or number of hosts scales up.
+**Action:** Use an O(T+H) map aggregation strategy by iterating over `tasks` first to group data, then iterating over `hosts` to map that grouped data to limiters.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,49 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	type hostData struct {
+		hasActiveTasks bool
+		activeCount    int
+		hostSpeedBps   float64
+	}
+
+	// Aggregate task data per host in a single pass O(T)
+	agg := make(map[string]*hostData)
+	for _, t := range qm.tasks {
+		h := t.Config.Host
+		if agg[h] == nil {
+			agg[h] = &hostData{}
 		}
+		data := agg[h]
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			data.hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				data.activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						data.hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
+
+	var stats []models.HostStats
+	// Match aggregated data with limiters O(H)
+	for host, limiter := range qm.limiters {
+		data := agg[host]
+		if data != nil && data.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    data.activeCount,
+				TotalSpeedKBps: data.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
### 💡 What
Refactored `GetHostStats()` in `internal/queue/manager.go` to use an $O(T)$ map aggregation instead of iterating over the full `qm.tasks` array for every limiter.

### 🎯 Why
The `GetHostStats` endpoint is frequently polled, and its original implementation used an $O(T \times H)$ nested loop while holding a read mutex `qm.mu.RLock()`. As the queue and number of hosts grows, this can cause unnecessary lock contention and slow down the endpoint.

### 📊 Impact
Changes time complexity from $O(T \times H)$ to $O(T+H)$ where `T` is active tasks and `H` is the number of host limiters, improving API response times and significantly reducing lock duration under load.

### 🔬 Measurement
Run `go test ./...` to verify all tests still pass and verify the original behaviour of the function remains intact.

---
*PR created automatically by Jules for task [5360251411809439540](https://jules.google.com/task/5360251411809439540) started by @arumes31*