### PR TITLE
🎨 Palette: Improve accessibility and micro-UX for file checkboxes

### DIFF
--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = "Directories cannot be selected directly";
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 What: Added an `aria-label` attribute (e.g., `Select file.txt`) to dynamically generated file checkboxes, and a `title` attribute to disabled directory checkboxes explaining that "Directories cannot be selected directly".
🎯 Why: To improve accessibility for screen reader users by providing clear context on what each checkbox controls, and to improve micro-UX for sighted users by explaining why directory checkboxes are inactive via a native tooltip.
📸 Before/After: Visual changes are limited to a new native browser tooltip on hover over disabled checkboxes.
♿ Accessibility: Improves WCAG compliance by ensuring interactive form elements have clear accessible names, and provides context for disabled states.

---
*PR created automatically by Jules for task [749524019739833242](https://jules.google.com/task/749524019739833242) started by @arumes31*