### PR TITLE
⚡ Bolt: Replace O(T*H) nested loops with O(T+H) map aggregation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+## 2026-05-18 - O(N) HashMap aggregation replaces O(N^2) loops
+**Learning:** Running an O(T*H) double-loop inside a Read/Write Mutex critical section for the `/api/stats` endpoint slows down everything and locks up CPU, especially since the UI polls this endpoint frequently.
+**Action:** Use a single-pass O(T+H) aggregation using maps before producing final lists to minimize lock time and CPU burn.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,48 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
+	// ⚡ Bolt: Replace O(T*H) nested loops with O(T+H) map aggregation
+	// 📊 Impact: Significantly reduces CPU usage and read-lock contention on frequently polled /api/stats
+	type hostAggr struct {
+		hasActive    bool
+		activeCount  int
+		hostSpeedBps float64
+	}
+	aggrs := make(map[string]*hostAggr)
+
+	// Single O(T) pass over tasks
+	for _, t := range qm.tasks {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			h := t.Config.Host
+			if aggrs[h] == nil {
+				aggrs[h] = &hostAggr{}
 			}
-		}
-
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+			aggrs[h].hasActive = true
+			if t.Status == models.TaskRunning {
+				aggrs[h].activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						aggrs[h].hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
 
+	var stats []models.HostStats
+	// Single O(H) pass over limiters
+	for host, limiter := range qm.limiters {
+		aggr, ok := aggrs[host]
+		if ok && aggr.hasActive {
+			curr, max, lat := limiter.GetStats()
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    aggr.activeCount,
+				TotalSpeedKBps: aggr.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 **What**: Refactored `QueueManager.GetHostStats()` to pre-aggregate active task metrics per host using a single O(T) pass over tasks, storing results in a hash map, followed by a single O(H) pass over limiters.
🎯 **Why**: The previous implementation used an O(T*H) nested loop algorithm inside a read-lock (`qm.mu.RLock()`). Because the `/api/stats` endpoint is frequently polled by the frontend, this caused significant read-lock contention and CPU burn, blocking queue workers and other API endpoints.
📊 **Impact**: Reduces time complexity from O(T*H) to O(T+H). Drastically lowers CPU usage and lock contention duration, ensuring the application stays responsive even with many active tasks and configured hosts.
🔬 **Measurement**: Verified the Go test suite passes. Lock contention can be benchmarked using Go pprof on the `/api/stats` endpoint under simulated load.

---
*PR created automatically by Jules for task [307968438156300201](https://jules.google.com/task/307968438156300201) started by @arumes31*