### PR TITLE
⚡ Bolt: Optimize GetHostStats to O(T+H) aggregation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+## 2024-05-25 - Avoid O(T*H) Nested Loops in Mutex Critical Sections
+**Learning:** Using nested loops for data aggregation inside a read/write mutex critical section, especially in frequently polled API endpoints like `GetHostStats`, causes significant lock contention. Here, iterating tasks per host resulted in O(T*H) complexity.
+**Action:** When aggregating states from multiple collections protected by a read/write mutex, use map aggregation to convert O(T*H) operations into O(T+H). Build an aggregated state map from one collection first, then correlate it with the other to minimize time spent holding the lock.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -490,40 +490,44 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	defer qm.mu.RUnlock()
 
 	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	// ⚡ Bolt: Use O(T+H) map aggregation instead of O(T*H) nested loops to prevent lock contention on qm.mu
+	type hostAgg struct {
+		hasActiveTasks bool
+		activeCount    int
+		speedBps       float64
+	}
+	agg := make(map[string]*hostAgg)
+
+	for _, t := range qm.tasks {
+		h := t.Config.Host
+		if agg[h] == nil {
+			agg[h] = &hostAgg{}
 		}
-
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			agg[h].hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				agg[h].activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						agg[h].speedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
 
+	for host, limiter := range qm.limiters {
+		a := agg[host]
+		if a != nil && a.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    a.activeCount,
+				TotalSpeedKBps: a.speedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 What: Optimized `GetHostStats` to use an $O(T+H)$ map aggregation approach instead of iterating $O(T \times H)$ nested loops while inside a read/write lock.
🎯 Why: Iterating over tasks inside a loop for each host limits execution time inside the mutex lock. For applications where many hosts and tasks are expected, taking a performance penalty under the critical section caused significant performance bottlenecks and lock contentions. 
📊 Impact: Considerably faster API performance and reduced lock contention on the `QueueManager`'s mutex, reducing execution time complexity of stat retrieval. 
🔬 Measurement: Verify changes in throughput of backend statistics operations or monitor CPU utilization within locked critical sections on `/api/stats`.

---
*PR created automatically by Jules for task [14671390417530148367](https://jules.google.com/task/14671390417530148367) started by @arumes31*