### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS memory exhaustion vector in queue limiters

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Prevention:**
 1. Used a robust `escapeHTML` helper function in `ui/static/app.js` to encode HTML entities (`&`, `<`, `>`, `"`, `'`) before using them in DOM elements constructed via `innerHTML`.
 2. Replaced the standard password string comparison (`!=`) in `internal/api/server.go` with `subtle.ConstantTimeCompare` from the `crypto/subtle` package to ensure the comparison time is independent of the input contents.
+## 2025-02-25 - In-Memory Map Bounding for DoS Prevention
+**Vulnerability:** The `qm.limiters` map in `QueueManager` could grow infinitely, leading to a memory exhaustion DoS if an attacker repeatedly submitted requests with unique `Host` values.
+**Learning:** In-memory tracking maps used for rate limiting or caching must have strict bounds and safe eviction policies to prevent attackers from causing memory leaks or denial of service through exhaustion.
+**Prevention:** Always implement bounded map limits with an $O(T+H)$ eviction strategy (clearing inactive entries based on current tasks) when creating caching or tracking maps. Ensure an un-cached fallback instance is safely returned if the eviction cannot free space.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -220,6 +220,22 @@ func (qm *QueueManager) getOrCreateLimiter(config models.UploadRequest) *sftpcli
 		if int(limit)/10 > burst {
 			burst = int(limit) / 10
 		}
+
+		if len(qm.limiters) >= 100 {
+			activeHosts := make(map[string]bool)
+			for _, t := range qm.tasks {
+				activeHosts[t.Config.Host] = true
+			}
+			for h := range qm.limiters {
+				if !activeHosts[h] {
+					delete(qm.limiters, h)
+				}
+			}
+			if len(qm.limiters) >= 100 {
+				return sftpclient.NewLimiter(limit, rate.Limit(burst), minLimit, maxLat)
+			}
+		}
+
 		limiter = sftpclient.NewLimiter(limit, rate.Limit(burst), minLimit, maxLat)
 		qm.limiters[host] = limiter
 		return limiter


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: An attacker could cause memory exhaustion (DoS) by continuously submitting requests with unique, random `host` parameters, causing the `qm.limiters` map in `QueueManager` to grow indefinitely.
🎯 Impact: The server could run out of memory and crash, leading to a denial of service.
🔧 Fix: Implemented an $O(T+H)$ map bounding and eviction strategy inside `getOrCreateLimiter`. The code now sets a cap of 100 on `qm.limiters`. Before inserting a new limiter, it evicts all inactive limiters (those not associated with currently pending/running tasks). If the capacity remains full after eviction, a fallback un-cached limiter is safely returned to ensure operations continue without crashing the system.
✅ Verification: Tested against existing queue tests to ensure limiters are appropriately created and fallback is hit without panicking.

---
*PR created automatically by Jules for task [8058152974594716531](https://jules.google.com/task/8058152974594716531) started by @arumes31*