### PR TITLE
🎨 Palette: Add accessible labels to local file checkboxes

### DIFF
--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = 'Directories cannot be selected directly';
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 What:
Added `aria-label` to the dynamically generated file checkboxes in the local file browser. Added a `title` tooltip to the disabled directory checkboxes to explain why they are inactive.

🎯 Why:
To improve screen reader context for file selection and to reduce user confusion when hovering over disabled directory checkboxes.

♿ Accessibility:
- Screen readers will now announce "Select [filename]" instead of generic "checkbox".
- Visual users get a clear explanation for disabled state.

---
*PR created automatically by Jules for task [17249271375140057057](https://jules.google.com/task/17249271375140057057) started by @arumes31*