### PR TITLE
⚡ Bolt: Optimize QueueManager.GetHostStats to O(T+H)

### DIFF
--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,50 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	// ⚡ Bolt: Optimized nested loop O(T * H) to map aggregation O(T+H) to prevent lock contention
+	type hostAgg struct {
+		hasActiveTasks bool
+		activeCount    int
+		hostSpeedBps   float64
+	}
+	aggs := make(map[string]*hostAgg)
+
+	for _, t := range qm.tasks {
+		host := t.Config.Host
+		agg, exists := aggs[host]
+		if !exists {
+			agg = &hostAgg{}
+			aggs[host] = agg
 		}
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			agg.hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				agg.activeCount++
 
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						agg.hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
+
+	var stats []models.HostStats
+	for host, limiter := range qm.limiters {
+		agg, exists := aggs[host]
+		if exists && agg.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    agg.activeCount,
+				TotalSpeedKBps: agg.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 **What:** Optimized `QueueManager.GetHostStats()` to use an $O(T+H)$ map aggregation approach instead of an $O(T \times H)$ nested loop.
🎯 **Why:** The method previously looped through the entire `tasks` list for every `host` in the limiters map. Since this is executed under a read lock (`qm.mu.RLock()`), it created potential for lock contention on a frequently polled endpoint (like `/api/stats`), especially when the queue grows large.
📊 **Impact:** Reduces algorithmic complexity from $O(T \times H)$ to $O(T + H)$, significantly reducing the read-lock duration and improving application responsiveness.
🔬 **Measurement:** Code correctly builds and runs without any regressions, and `go test ./...` verifies nothing is broken.

---
*PR created automatically by Jules for task [14424782605882974502](https://jules.google.com/task/14424782605882974502) started by @arumes31*