### PR TITLE
⚡ Bolt: Optimize GetHostStats to O(T+H)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+## 2025-05-25 - Avoid O(T*H) Nested Loops in Critical Sections
+**Learning:** Using an O(T*H) nested loop algorithm inside a read lock when querying frequently accessed stats endpoints causes unnecessary lock contention and performance bottlenecks. The memory context mentions to avoid this and optimize with O(T+H).
+**Action:** Always use (T+H)$ map aggregation for aggregating statistics across multiple items instead of nested loops inside lock critical sections.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -490,40 +490,44 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	defer qm.mu.RUnlock()
 
 	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
+
+	// ⚡ Bolt: Use O(T+H) map aggregation instead of O(T*H) nested loops to reduce lock contention
+	type hostMetrics struct {
+		activeCount  int
+		hostSpeedBps float64
+	}
+	metrics := make(map[string]*hostMetrics)
+
+	for _, t := range qm.tasks {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			m, ok := metrics[t.Config.Host]
+			if !ok {
+				m = &hostMetrics{}
+				metrics[t.Config.Host] = m
 			}
-		}
-
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+			if t.Status == models.TaskRunning {
+				m.activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						m.hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
+
+	for host, limiter := range qm.limiters {
+		if m, hasActiveTasks := metrics[host]; hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    m.activeCount,
+				TotalSpeedKBps: m.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 **What:** Refactored the `GetHostStats` function in `internal/queue/manager.go` to use map aggregation, reducing the algorithmic complexity from $O(T \times H)$ to $O(T + H)$ (where T = number of tasks, H = number of hosts).

🎯 **Why:** The previous implementation used nested loops while holding a read lock (`qm.mu.RLock()`). As the queue size and host count grow, this causes unnecessary lock contention and blocks the system, especially since this function is frequently polled by the `/api/stats` endpoint.

📊 **Impact:** Significantly reduces CPU cycles and read lock hold times during stats polling. Resolves a potential bottleneck that could cause the entire queue manager to slow down during bursts of tasks.

🔬 **Measurement:** Code correctly passes all unit tests, `go vet`, and is properly formatted. The refactor was manually inspected to ensure logical equivalence.

---
*PR created automatically by Jules for task [7188184876171611420](https://jules.google.com/task/7188184876171611420) started by @arumes31*