### PR TITLE
🎨 Palette: Improve accessibility of file selection checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2026-05-21 - Added Accessibility Attributes to Dynamic Checkboxes
+**Learning:** Found that dynamically generated checkboxes in the vanilla JS file list lacked `aria-label` attributes, making them inaccessible to screen readers. Furthermore, when disabled (e.g., for directories), there was no semantic or visual explanation why they were inactive.
+**Action:** Always add context-specific `aria-label` attributes (e.g., incorporating the file name) to dynamic form elements like checkboxes. For disabled elements, include a `title` attribute explicitly explaining the restriction to improve UX clarity.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select file ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = "Directories cannot be selected directly";
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 **What:** Added `aria-label` to the dynamic file checkboxes containing the file name. Added a `title` attribute to the disabled checkboxes for directories explaining why they cannot be selected.
🎯 **Why:** To make the file selection list screen-reader friendly and improve general user experience by clarifying disabled states.
📸 **Before/After:** Visually identical, but functionally superior.
♿ **Accessibility:** Screen readers will now announce "Select file [filename]" instead of just "checkbox". Hovering over a disabled directory checkbox will now show a tooltip saying "Directories cannot be selected directly".

---
*PR created automatically by Jules for task [18268022435524653998](https://jules.google.com/task/18268022435524653998) started by @arumes31*