### PR TITLE
⚡ Bolt: Replace O(T*H) nested loop with O(T+H) aggregation in QueueManager.GetHostStats

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2024-05-22 - Optimize nested loops within critical lock sections
+**Learning:** O(T*H) nested loop computation within a read/write mutex like `QueueManager.mu` can create massive lock contention when processing `/api/stats` repeatedly under load.
+**Action:** Pre-aggregate task data into a map in O(T) within the lock, then iterate the H hosts in O(H) using map lookups. This achieves O(T+H) complexity and vastly reduces the lock duration.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,45 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	// ⚡ Bolt: Replace O(T*H) nested loop with O(T+H) map aggregation to reduce lock contention
+	type hostAgg struct {
+		hasActiveTasks bool
+		activeCount    int
+		hostSpeedBps   float64
+	}
+	agg := make(map[string]*hostAgg)
+
+	for _, t := range qm.tasks {
+		h := t.Config.Host
+		if agg[h] == nil {
+			agg[h] = &hostAgg{}
 		}
-
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			agg[h].hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				agg[h].activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						agg[h].hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
 
+	var stats []models.HostStats
+	for host, limiter := range qm.limiters {
+		ha := agg[host]
+		if ha != nil && ha.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    ha.activeCount,
+				TotalSpeedKBps: ha.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 What: Refactored `QueueManager.GetHostStats` to replace an O(T*H) nested loop with an O(T+H) map aggregation strategy.
🎯 Why: Iterating over all tasks `T` twice for every host limiter `H` within the `qm.mu.RLock()` creates massive lock contention when processing `/api/stats` repeatedly under load.
📊 Impact: Reduces time complexity from O(T*H) to O(T+H), vastly reducing the lock duration and preventing UI/worker freezes under heavy task loads.
🔬 Measurement: Run the application with multiple hosts and a high number of active tasks, repeatedly poll `/api/stats`, and observe the decreased latency and lock contention compared to previous iterations.

---
*PR created automatically by Jules for task [15976820817811766547](https://jules.google.com/task/15976820817811766547) started by @arumes31*