### PR TITLE
🎨 Palette: Add accessibility to file checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
+## 2026-05-22 - Improved accessibility for dynamically generated form elements
+**Learning:** Dynamically generated form elements (like checkboxes in lists) often lack context for screen reader users and disabled states can be confusing without explanation.
+**Action:** Always add `aria-label` attributes to dynamically generated interactive elements for screen reader context and use `title` attributes on disabled elements to explicitly explain why they are inactive.
+
 ## 2026-03-05 - Adding accessibility to toggle buttons
 **Learning:** Found that layout toggles (`view-toggle-btn`) and view options (`compact-toggle`) missed dynamic ARIA attributes, leaving screen reader users without proper context of the current interface state.
 **Action:** When creating toggle buttons or dropdown buttons, always pair with `aria-pressed` or `aria-expanded` and `aria-haspopup` to properly convey state changes and control relationships.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = "Directories cannot be selected directly";
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 **What:** Added `aria-label` attribute to dynamically generated checkboxes for screen reader context and added a `title` attribute to explicitly explain why directories are disabled.
🎯 **Why:** Dynamically generated form elements (like checkboxes in lists) often lack context for screen reader users, and disabled states can be confusing without explanation.
♿ **Accessibility:** This ensures that visually impaired users relying on screen readers have proper context for these input elements, and that all users can easily understand the disabled states via the tooltip.

---
*PR created automatically by Jules for task [340123115590680022](https://jules.google.com/task/340123115590680022) started by @arumes31*