### PR TITLE
🛡️ Sentinel: [HIGH] Fix brute-force vulnerability on login endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Prevention:**
 1. Used a robust `escapeHTML` helper function in `ui/static/app.js` to encode HTML entities (`&`, `<`, `>`, `"`, `'`) before using them in DOM elements constructed via `innerHTML`.
 2. Replaced the standard password string comparison (`!=`) in `internal/api/server.go` with `subtle.ConstantTimeCompare` from the `crypto/subtle` package to ensure the comparison time is independent of the input contents.
+## 2026-05-22 - [Fix login endpoint brute-force vulnerability]
+**Vulnerability:** The `/api/login` endpoint lacked any mechanism for rate-limiting authentication attempts, allowing attackers to mount brute-force or credential stuffing attacks uninterrupted.
+**Learning:** The issue existed because there was no global or per-IP throttling in the application logic. However, adding an IP-based rate limiter to the login endpoint introduced a data race because `time.Time` is a multi-word struct containing a pointer, and concurrent writes without an exclusive lock (`Lock()`) lead to torn values.
+**Prevention:** In Go, always use an exclusive lock when mutating `time.Time` fields. Avoid using `RLock()` when mutating any struct fields, even if it feels like a "read-mostly" operation.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	pathpkg "path"
@@ -21,12 +22,62 @@ import (
 	"uplarr/internal/queue"
 	"uplarr/internal/sftpclient"
 	"uplarr/ui"
+
+	"golang.org/x/time/rate"
 )
 
 var (
 	sessions   = make(map[string]bool)
 	sessionsMu sync.RWMutex
 )
+
+type ipLimiter struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+type loginRateLimiter struct {
+	limiters map[string]*ipLimiter
+	mu       sync.RWMutex
+	rate     rate.Limit
+	burst    int
+}
+
+func newLoginRateLimiter(r rate.Limit, b int) *loginRateLimiter {
+	return &loginRateLimiter{
+		limiters: make(map[string]*ipLimiter),
+		rate:     r,
+		burst:    b,
+	}
+}
+
+func (l *loginRateLimiter) getLimiter(ip string) *rate.Limiter {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if v, exists := l.limiters[ip]; exists {
+		v.lastSeen = time.Now()
+		return v.limiter
+	}
+
+	if len(l.limiters) > 1000 {
+		now := time.Now()
+		for k, v := range l.limiters {
+			if now.Sub(v.lastSeen) > 3*time.Minute {
+				delete(l.limiters, k)
+			}
+		}
+		if len(l.limiters) > 1000 {
+			return rate.NewLimiter(l.rate, l.burst)
+		}
+	}
+
+	newLimiter := rate.NewLimiter(l.rate, l.burst)
+	l.limiters[ip] = &ipLimiter{limiter: newLimiter, lastSeen: time.Now()}
+	return newLimiter
+}
+
+var loginLimiter = newLoginRateLimiter(rate.Every(time.Second), 5)
 
 func generateToken() (string, error) {
 	b := make([]byte, 32)
@@ -158,6 +209,24 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 			w.WriteHeader(http.StatusOK)
 			return
 		}
+
+		ip, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			ip = r.RemoteAddr
+		}
+		if config.TrustProxy {
+			if forwardedFor := r.Header.Get("X-Forwarded-For"); forwardedFor != "" {
+				ips := strings.Split(forwardedFor, ",")
+				ip = strings.TrimSpace(ips[0])
+			}
+		}
+
+		if !loginLimiter.getLimiter(ip).Allow() {
+			logger.Warn(fmt.Sprintf("Rate limit exceeded for login from IP: %s", ip))
+			http.Error(w, "Too many requests", http.StatusTooManyRequests)
+			return
+		}
+
 		var loginReq struct {
 			Password string `json:"password"`
 		}


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `/api/login` endpoint lacked rate limiting, allowing attackers to perform unlimited brute-force password guessing or credential stuffing attacks.
🎯 **Impact:** If exploited, attackers could bypass authentication by systematically guessing passwords until they find the correct one, leading to unauthorized access.
🔧 **Fix:** Implemented an IP-based rate limiter using `golang.org/x/time/rate`. It restricts login attempts to 1 per second with a burst of 5. It includes an eviction mechanism to prevent memory exhaustion DoS attacks by removing inactive IP entries after 3 minutes if the map grows too large. It checks the `X-Forwarded-For` header if `config.TrustProxy` is enabled.
✅ **Verification:** Verified by checking the logs for "Rate limit exceeded" after attempting multiple rapid logins. Tests passing with `go test ./... -race`.

---
*PR created automatically by Jules for task [16443739105319455462](https://jules.google.com/task/16443739105319455462) started by @arumes31*