### PR TITLE
⚡ Bolt: Optimize GetHostStats to O(T+H)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+## 2025-05-25 - Avoid O(T*H) Nested Loops in QueueManager
+**Learning:** The Go backend's `QueueManager` uses an in-memory task slice (`qm.tasks`) and host limiters map (`qm.limiters`) protected by a read/write mutex (`qm.mu`). Operations within this lock must remain optimized (e.g., using $O(T+H)$ map aggregation instead of $O(T \times H)$ nested loops) to prevent lock contention and avoid blocking frequently polled API endpoints like `/api/stats`.
+**Action:** When aggregating statistics across multiple collections inside a locked region, prioritize $O(N)$ single-pass aggregation into intermediate maps instead of $O(N^2)$ nested iterations.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -485,45 +485,53 @@ func (qm *QueueManager) GetTasks() []*models.Task {
 	return snapshot
 }
 
+// ⚡ Bolt: Replace O(T*H) nested loops with O(T+H) map aggregation for GetHostStats
 func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	type hostAggr struct {
+		hasActiveTasks bool
+		activeCount    int
+		hostSpeedBps   float64
+	}
+	aggrs := make(map[string]*hostAggr)
+
+	// Single O(T) pass over tasks to aggregate stats per host
+	for _, t := range qm.tasks {
+		h := t.Config.Host
+		aggr, ok := aggrs[h]
+		if !ok {
+			aggr = &hostAggr{}
+			aggrs[h] = aggr
 		}
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			aggr.hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				aggr.activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						aggr.hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
 
+	var stats []models.HostStats
+	// Single O(H) pass over limiters
+	for host, limiter := range qm.limiters {
+		if aggr, ok := aggrs[host]; ok && aggr.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    aggr.activeCount,
+				TotalSpeedKBps: aggr.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 What:
Replaced the nested loops in `QueueManager.GetHostStats` that iterated over all tasks for every host. It now uses a single $O(T)$ pass over the tasks to aggregate stats into a map, followed by a single $O(H)$ pass over the limiters.

🎯 Why:
The previous $O(T \times H)$ implementation ran entirely inside a read lock (`qm.mu.RLock()`). Because this method is called frequently by the `/api/stats` endpoint, holding the lock for a potentially long time with a large number of tasks and hosts could cause severe lock contention, blocking workers and freezing the application.

📊 Impact:
Reduces time complexity of `GetHostStats` from $O(T \times H)$ to $O(T + H)$. This significantly reduces the time the lock is held under heavy load.

🔬 Measurement:
Start the application and add many tasks across multiple hosts. The `/api/stats` endpoint will remain responsive and CPU usage during polling will be noticeably reduced.

---
*PR created automatically by Jules for task [12501458223045804597](https://jules.google.com/task/12501458223045804597) started by @arumes31*