### PR TITLE
🎨 Palette: Keyboard Accessibility Enhancements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2026-05-23 - Adding accessibility to file rows and checkboxes
+**Learning:** Found that custom interactive elements like `.clickable-row` representing file and directory lists lacked keyboard support (tabIndex, keydown) and descriptive ARIA labels, making them inaccessible to screen readers and keyboard-only users. Additionally, disabled checkboxes lacked context for why they were disabled.
+**Action:** When creating custom interactive rows or lists, ensure they receive focus via `tabIndex`, respond to `Enter` and `Space` keys, and have descriptive `aria-label`s. Always provide tooltips (`title` attribute) for disabled elements to explain the constraint to the user.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -953,8 +953,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (file.is_dir) {
                 row.className = 'clickable-row folder-row';
-                row.addEventListener('click', (e) => {
+                row.tabIndex = 0;
+                row.setAttribute('aria-label', `Open directory ${file.name}`);
+                const openDir = (e) => {
                     if (e.target.type !== 'checkbox') fetchFiles(fullRelPath);
+                };
+                row.addEventListener('click', openDir);
+                row.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        openDir(e);
+                    }
                 });
             } else {
                 row.draggable = true;
@@ -976,7 +985,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = "Directories cannot be selected for upload";
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {
@@ -1131,9 +1144,18 @@ document.addEventListener('DOMContentLoaded', () => {
             const row = document.createElement('tr');
             if (file.is_dir) {
                 row.className = 'clickable-row folder-row';
-                row.addEventListener('click', () => {
+                row.tabIndex = 0;
+                row.setAttribute('aria-label', `Open directory ${file.name}`);
+                const openDir = () => {
                     const newPath = remoteCurrentPath.endsWith('/') ? remoteCurrentPath + file.name : remoteCurrentPath + '/' + file.name;
                     fetchRemoteFiles(newPath);
+                };
+                row.addEventListener('click', openDir);
+                row.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        openDir();
+                    }
                 });
             }
 


### PR DESCRIPTION
💡 What: Added comprehensive keyboard accessibility and screen reader support to the file browser rows and checkboxes.
🎯 Why: Custom interactive elements (`.clickable-row`) were previously only navigable via mouse clicks and lacked context for screen readers, isolating keyboard-only and assistive technology users. Disabled elements didn't explain their state.
📸 Before/After: Visuals remained identical, but focus states and native tooltips are now present.
♿ Accessibility:
- Added `tabIndex="0"` and `keydown` event listeners for `Enter` and `Space` to local and remote directory rows.
- Added `aria-label` to directory rows to announce "Open directory [name]".
- Added `aria-label` to local file checkboxes to announce "Select [name]".
- Added `title` attribute to disabled checkboxes ("Directories cannot be selected for upload") to explain the inactive state.

---
*PR created automatically by Jules for task [17104023828618075872](https://jules.google.com/task/17104023828618075872) started by @arumes31*