### PR TITLE
🎨 Palette: Add accessible labels and tooltips to file list checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
+## 2026-05-24 - Accessible Dynamically Generated Inputs
+**Learning:** Dynamically generated input elements often miss ARIA attributes and helpful titles if not explicitly set during creation, causing screen readers to lack context and users to not understand why certain inputs are disabled.
+**Action:** Always include `aria-label` and `title` assignments when dynamically creating inputs like checkboxes in JavaScript.
 ## 2026-03-05 - Adding accessibility to toggle buttons
 **Learning:** Found that layout toggles (`view-toggle-btn`) and view options (`compact-toggle`) missed dynamic ARIA attributes, leaving screen reader users without proper context of the current interface state.
 **Action:** When creating toggle buttons or dropdown buttons, always pair with `aria-pressed` or `aria-expanded` and `aria-haspopup` to properly convey state changes and control relationships.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,15 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = "Cannot queue directories directly";
+            } else {
+                cb.title = `Select ${file.name}`;
+            }
+
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` and `title` attributes to file list checkboxes in the vanilla JS frontend.
🎯 Why: Dynamically generated checkboxes lacked accessible labels for screen readers. Directory checkboxes are disabled without explanation; the new title tooltip provides clear UX context on why they cannot be selected.
📸 Before/After: Verified visually via Playwright tests. Tooltips display on hover over disabled directory rows.
♿ Accessibility: Improved screen reader support and clarity on interactive vs disabled states.

---
*PR created automatically by Jules for task [2637341369824189165](https://jules.google.com/task/2637341369824189165) started by @arumes31*