### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to disabled file checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2026-05-25 - Added ARIA labels and title to disabled checkboxes
+**Learning:** Found that dynamically created file checkboxes for directories were disabled without providing clear visual explanations or accessible labels for screen readers.
+**Action:** When dynamically generating form elements like checkboxes, always add `aria-label` for screen reader context and `title` attributes on disabled elements to explain why they are inactive.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.setAttribute('title', 'Directories cannot be selected');
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 What: Added an `aria-label` attribute to dynamically created file selection checkboxes for better context and a `title` attribute to explicitly explain to users why directory checkboxes are disabled.
🎯 Why: Disabled inputs without explanation create poor user experiences. Missing ARIA labels degrade screen reader accessibility for dynamic file listings.
📸 Before/After: Before, checkboxes lacked accessible names and disabled checkboxes provided no tooltip. Now, hovering over disabled directories explains "Directories cannot be selected," and screen readers read "Select <filename>".
♿ Accessibility: Improved keyboard and screen reader accessibility by ensuring inputs have proper accessible labels and states.

---
*PR created automatically by Jules for task [8565561180856644524](https://jules.google.com/task/8565561180856644524) started by @arumes31*