### PR TITLE
🎨 Palette: Add accessibility attributes to file checkboxes

### DIFF
--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = 'Directories cannot be selected';
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 **What:** Added `aria-label` to file checkboxes and `title` to disabled directory checkboxes in `ui/static/app.js`.
🎯 **Why:** To improve screen reader accessibility by providing context to the checkboxes (`aria-label`) and enhance usability by explicitly explaining why directory checkboxes cannot be clicked (`title`).
📸 **Before/After:** Visually verified locally using Playwright to confirm attributes are set correctly on the `#file-list-body` row checkboxes.
♿ **Accessibility:** Screen reader users will now hear the name of the specific file when focusing on a checkbox, rather than just "checkbox". Mouse/keyboard users now get a helpful tooltip when hovering/focusing over disabled directory checkboxes.

---
*PR created automatically by Jules for task [15222488101728885536](https://jules.google.com/task/15222488101728885536) started by @arumes31*