### PR TITLE
⚡ Bolt: Optimize GetHostStats to O(T+H)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2026-05-27 - Optimizing QueueManager GetHostStats Lock Contention
+**Learning:** Running an O(T x H) nested loop while holding a read mutex on frequently accessed endpoints creates performance degradation when tasks and hosts count scales.
+**Action:** Use an O(T + H) map aggregation to process tasks by host in a single pass before iterating over the hosts, greatly reducing execution time under the lock.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,47 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	// Aggregate task data by host in a single pass O(T)
+	type hostAggregation struct {
+		hasActiveTasks bool
+		activeCount    int
+		totalSpeedBps  float64
+	}
+	agg := make(map[string]*hostAggregation)
+
+	for _, t := range qm.tasks {
+		h := t.Config.Host
+		if agg[h] == nil {
+			agg[h] = &hostAggregation{}
 		}
-
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			agg[h].hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				agg[h].activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						agg[h].totalSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
+
+	var stats []models.HostStats
+	// Iterate through limiters O(H)
+	for host, limiter := range qm.limiters {
+		ha := agg[host]
+		if ha != nil && ha.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    ha.activeCount,
+				TotalSpeedKBps: ha.totalSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 What: Refactored `QueueManager.GetHostStats()` to pre-aggregate task statistics into a map before iterating over the active host limiters.
🎯 Why: The original implementation contained an O(T x H) nested loop (where T=tasks, H=hosts) inside a read mutex (`qm.mu.RLock()`). When the queue fills up and there are multiple hosts, this block holds the lock for much longer, blocking other fast API endpoints and delaying workers.
📊 Impact: Changes performance complexity inside the lock from O(T x H) to O(T + H). Reduces execution time and reduces overall read-lock contention on the highly-accessed `/api/stats` endpoint.
🔬 Measurement: Wait for workers to begin under load. API calls to `/api/stats` should be more resilient to queue buildup. Code passes all tests.

---
*PR created automatically by Jules for task [8367441905138649050](https://jules.google.com/task/8367441905138649050) started by @arumes31*