### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS memory exhaustion in limiters map

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,8 @@
 **Prevention:**
 1. Used a robust `escapeHTML` helper function in `ui/static/app.js` to encode HTML entities (`&`, `<`, `>`, `"`, `'`) before using them in DOM elements constructed via `innerHTML`.
 2. Replaced the standard password string comparison (`!=`) in `internal/api/server.go` with `subtle.ConstantTimeCompare` from the `crypto/subtle` package to ensure the comparison time is independent of the input contents.
+
+## 2026-05-27 - Prevent DoS Memory Exhaustion in Tracking Maps
+**Vulnerability:** Unbounded in-memory map tracking rate limiters (`qm.limiters`) per host allows a malicious user or numerous unauthenticated requests with unique hosts to exhaust server memory, leading to a Denial of Service (DoS).
+**Learning:** Maps used for state tracking (e.g., rate limiting, metrics) without eviction mechanisms represent a severe memory leak vector. Bounding and evicting items safely prevents this.
+**Prevention:** Implement safe map bounds and evictions. Evict inactive entries when exceeding a threshold (e.g., 100). When full and all entries are active, forceful eviction of an arbitrary/oldest entry must be used rather than throwing errors or skipping caching to maintain rate-limiting properties and bound memory.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -216,6 +216,33 @@ func (qm *QueueManager) getOrCreateLimiter(config models.UploadRequest) *sftpcli
 
 	limiter, exists := qm.limiters[host]
 	if !exists {
+		// Bounded map to prevent DoS memory exhaustion
+		if len(qm.limiters) >= 100 {
+			activeHosts := make(map[string]bool)
+			for _, t := range qm.tasks {
+				if t.Status == models.TaskPending || t.Status == models.TaskRunning || t.Status == models.TaskPaused {
+					activeHosts[t.Config.Host] = true
+				}
+			}
+
+			evicted := false
+			for h := range qm.limiters {
+				if !activeHosts[h] {
+					delete(qm.limiters, h)
+					evicted = true
+					break
+				}
+			}
+
+			// Forcefully evict if limit reached and all are active
+			if !evicted {
+				for h := range qm.limiters {
+					delete(qm.limiters, h)
+					break
+				}
+			}
+		}
+
 		burst := 16 * 1024
 		if int(limit)/10 > burst {
 			burst = int(limit) / 10


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `qm.limiters` map in `internal/queue/manager.go` grows unbounded as new, unique hosts are encountered. This creates a Denial of Service (DoS) memory exhaustion vulnerability, where an attacker could flood the application with unauthenticated requests containing arbitrary hostnames to crash the server.
🎯 Impact: Unbounded memory growth leading to server application crash (OOM).
🔧 Fix: Implemented bounded eviction for the `qm.limiters` map. When the map exceeds 100 entries, it identifies all actively used hosts (pending, running, paused tasks) and evicts one inactive limiter. If all limiters are active, it forcefully evicts an arbitrary entry to ensure memory limits are respected.
✅ Verification: Ran `go test ./...` successfully and visually verified the logic via code review.

---
*PR created automatically by Jules for task [18241165987168457550](https://jules.google.com/task/18241165987168457550) started by @arumes31*