### PR TITLE
⚡ Bolt: Optimize GetHostStats to O(T+H) to reduce lock contention

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+## 2025-05-27 - Reduce lock contention via O(T+H) aggregation
+**Learning:** Nested loops $O(T \times H)$ inside heavily polled endpoints like `/api/stats` can hold RWMutex read locks for too long when both tasks and hosts lists are large. This blocks worker threads from acquiring write locks, creating a significant codebase bottleneck.
+**Action:** Always prefer flat map-based aggregations $O(T+H)$ when pulling multiple stats inside a mutex critical section to release the lock as quickly as possible.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -490,40 +490,53 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	defer qm.mu.RUnlock()
 
 	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+
+	// ⚡ Bolt: Optimize GetHostStats to prevent lock contention
+	// 💡 What: Replaced O(T × H) nested loop with O(T + H) map aggregation
+	// 🎯 Why: This endpoint is polled frequently (every 1s) by the UI. With many tasks and hosts,
+	// the nested loop holds the RWMutex for too long, blocking worker threads from acquiring the lock.
+	// 📊 Impact: Significantly reduces the time qm.mu is locked during stats polling.
+
+	type hostAgg struct {
+		hasActiveTasks bool
+		activeCount    int
+		totalSpeedBps  float64
+	}
+
+	// Single pass over tasks O(T)
+	agg := make(map[string]*hostAgg)
+	for _, t := range qm.tasks {
+		h := t.Config.Host
+		if agg[h] == nil {
+			agg[h] = &hostAgg{}
 		}
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			agg[h].hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				agg[h].activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						agg[h].totalSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
 
+	// Single pass over limiters O(H)
+	for host, limiter := range qm.limiters {
+		a := agg[host]
+		if a != nil && a.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    a.activeCount,
+				TotalSpeedKBps: a.totalSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 What: Replaced an O(T × H) nested loop inside `GetHostStats` with an O(T + H) map aggregation approach.
🎯 Why: The `/api/stats` endpoint is polled frequently (every 1s) by the UI. With many tasks and hosts, the nested loop held the RWMutex (`qm.mu`) for too long, blocking worker threads from acquiring write locks and creating a massive bottleneck.
📊 Impact: Significantly reduces the time `qm.mu` is read-locked during stats polling by using a flat map aggregation.
🔬 Measurement: Verify changes in `internal/queue/manager.go` and run the Go test suite.

---
*PR created automatically by Jules for task [1924091527198808112](https://jules.google.com/task/1924091527198808112) started by @arumes31*