### PR TITLE
⚡ Bolt: Optimize GetHostStats to O(T+H)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+## 2026-05-28 - O(N*M) aggregation inside read locks causes contention
+**Learning:** Performing nested loops to map tasks to hosts within the critical section of a read lock in `QueueManager.GetHostStats` created an (T \times H)$ operation, causing severe lock contention. Operations in locks must be minimized.
+**Action:** Always maintain (T+H)$ map aggregation structures (like calculating counts/sums in a single pass first) before joining with other collections when under a lock.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,45 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	// ⚡ Bolt: Optimize GetHostStats to O(T+H) by avoiding nested loops
+	// 📊 Impact: Prevents massive read lock contention when queue is large by mapping tasks once
+	type hostAgg struct {
+		activeCount  int
+		hostSpeedBps float64
+		hasTasks     bool
+	}
+	agg := make(map[string]*hostAgg)
+
+	for _, t := range qm.tasks {
+		h := t.Config.Host
+		if agg[h] == nil {
+			agg[h] = &hostAgg{}
 		}
-
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			agg[h].hasTasks = true
+			if t.Status == models.TaskRunning {
+				agg[h].activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						agg[h].hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
 
+	var stats []models.HostStats
+	for host, limiter := range qm.limiters {
+		if a, ok := agg[host]; ok && a.hasTasks {
+			curr, max, lat := limiter.GetStats()
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    a.activeCount,
+				TotalSpeedKBps: a.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 What: Refactored `QueueManager.GetHostStats()` to pre-aggregate task statistics into a hash map in a single pass over tasks, rather than looping over tasks for every single host limiter.
🎯 Why: The original implementation contained nested loops `O(H * T)` operating inside a critical read lock section. With a large queue, this blocks the entire application (lock contention).
📊 Impact: Reduces time complexity from `O(H * T)` to `O(H + T)`.
🔬 Measurement: Run a large queue with multiple hosts and poll `/api/stats`. Lock contention metrics will be significantly lower.

---
*PR created automatically by Jules for task [1978400452972754739](https://jules.google.com/task/1978400452972754739) started by @arumes31*