### PR TITLE
🎨 Palette: Add accessibility attributes to dynamic file list checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2026-06-03 - Adding accessibility to dynamic input fields
+**Learning:** Dynamically created input fields, like checkboxes, require `aria-label` to provide screen readers with context since they do not always have an explicit `<label>`. Additionally, disabled inputs need context (via `title` or similar attributes) so users understand *why* they are inaccessible.
+**Action:** Always include `aria-label` context and appropriate titles for conditionally disabled states when generating form fields dynamically in Javascript.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = "Directories cannot be selected directly";
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 **What:** Added `aria-label` context to the dynamically generated file list checkboxes and a `title` tooltip to the disabled directory checkboxes.
🎯 **Why:** Dynamically generated input fields without explicit labels are inaccessible to screen readers. Furthermore, a disabled state without a clear visual explanation (via tooltip/title) can confuse sighted users and keyboard navigators.
♿ **Accessibility:**
- Added `aria-label="Select [filename]"` for clear screen reader context.
- Added `title="Directories cannot be selected directly"` to disabled directory rows.

---
*PR created automatically by Jules for task [17693939475468410840](https://jules.google.com/task/17693939475468410840) started by @arumes31*