### PR TITLE
⚡ Bolt: Replace O(T*H) nested loops with O(T+H) map aggregation in stats API

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2026-05-30 - O(1) Data Aggregation during Read Locks
+**Learning:** Performing nested O(T*H) loops to aggregate task data inside a frequently polled API like `/api/stats` increases CPU load and significantly extends the hold time of read/write mutexes (`qm.mu.RLock()`), causing potential blocking on other queue operations.
+**Action:** When calculating statistics across subsets of data in-memory within a read-lock, use O(N) single-pass map aggregation instead of nested loops. This reduces time complexity from O(N*M) to O(N+M) and minimizes lock contention.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,43 +489,52 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	type hostMetrics struct {
+		hasActiveTasks bool
+		activeCount    int
+		hostSpeedBps   float64
+	}
+
+	// ⚡ Bolt: Aggregate task metrics per host in a single pass O(T)
+	metricsMap := make(map[string]*hostMetrics)
+	for _, t := range qm.tasks {
+		m, ok := metricsMap[t.Config.Host]
+		if !ok {
+			m = &hostMetrics{}
+			metricsMap[t.Config.Host] = m
 		}
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			m.hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				m.activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						m.hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
-
-			stats = append(stats, models.HostStats{
-				Host:           host,
-				LastLatencyMs:  lat.Milliseconds(),
-				CurrentLimitKB: curr,
-				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
-			})
 		}
+	}
+
+	var stats []models.HostStats
+	// ⚡ Bolt: Iterate over hosts and combine with O(T) aggregated task metrics, O(H)
+	for host, limiter := range qm.limiters {
+		m, ok := metricsMap[host]
+		if !ok || !m.hasActiveTasks {
+			continue
+		}
+
+		curr, max, lat := limiter.GetStats()
+		stats = append(stats, models.HostStats{
+			Host:           host,
+			LastLatencyMs:  lat.Milliseconds(),
+			CurrentLimitKB: curr,
+			MaxLimitKB:     max,
+			ActiveTasks:    m.activeCount,
+			TotalSpeedKBps: m.hostSpeedBps / 1024,
+		})
 	}
 	return stats
 }


### PR DESCRIPTION
💡 What: Refactored `QueueManager.GetHostStats()` to aggregate task metrics per host using a hash map in a single O(T) pass instead of iterating through all tasks for every single host.
🎯 Why: The original nested loop implementation had an O(T*H) time complexity. Because `GetHostStats()` is frequently polled by the frontend `/api/stats` endpoint, holding `qm.mu.RLock()` for the duration of the nested iterations could introduce lock contention and CPU spikes as the queue and host list grew.
📊 Impact: Reduces time complexity from O(T*H) to O(T+H), minimizing the duration the read lock is held and significantly improving API response times under heavy load.
🔬 Measurement: Run the Go benchmark suite, or observe lower CPU usage and faster `/api/stats` latency when thousands of active tasks are distributed across multiple hosts.

---
*PR created automatically by Jules for task [17509761319666573106](https://jules.google.com/task/17509761319666573106) started by @arumes31*