### PR TITLE
🎨 Palette: Improve file checkbox accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2025-02-12 - File List Checkbox Accessibility
+**Learning:** Dynamically generated input elements, like the checkboxes in the local file list, often lack context for screen readers when they are not associated with a specific `<label>`. Additionally, disabled states on inputs without explanation can lead to a confusing user experience.
+**Action:** Always include an `aria-label` attribute on standalone input elements to provide context (e.g., "Select [filename]"). Also, when programmatically disabling an element, provide a `title` or tooltip explaining why the element is inactive (e.g., "Directories cannot be selected for upload").

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = "Directories cannot be selected for upload";
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 **What:** 
Added `aria-label` properties to dynamically generated checkboxes in the local file list (`ui/static/app.js`) to read out the specific file name. Added a `title` attribute providing an explanation tooltip when checkboxes are disabled (for directories).

🎯 **Why:** 
Without an `aria-label`, screen readers may simply announce "checkbox" without context, making it impossible for visually impaired users to know which file they are selecting. Additionally, users may be confused why certain checkboxes (directories) are greyed out; the `title` attribute provides an immediate tooltip explaining "Directories cannot be selected for upload."

♿ **Accessibility:**
- Added screen reader context to checkboxes (`Select [filename]`).
- Explained disabled element state visually via tooltip.

---
*PR created automatically by Jules for task [12551924827894889208](https://jules.google.com/task/12551924827894889208) started by @arumes31*