### PR TITLE
⚡ Bolt: Optimize GetHostStats to O(T+H)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2024-05-30 - O(T*H) Nested Loops inside RLock
+**Learning:** Performing a nested loop over tasks and limiters (O(T*H)) inside a read lock (`qm.mu.RLock()`) for a frequently polled API endpoint (`/api/stats`) causes performance degradation due to lock contention and high CPU usage.
+**Action:** Always pre-aggregate metrics in a single pass over the elements (e.g. `O(T)`) to build an intermediate structure, then iterate the secondary collections (`O(H)`) resulting in linear `O(T+H)` complexity within critical sections.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,46 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
+	// ⚡ Bolt: Pre-aggregate host metrics to achieve O(T+H) instead of nested O(T*H) inside RLock
+	type hostAgg struct {
+		hasActive    bool
+		activeCount  int
+		hostSpeedBps float64
+	}
+	agg := make(map[string]*hostAgg, len(qm.limiters))
+
+	for _, t := range qm.tasks {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			h, ok := agg[t.Config.Host]
+			if !ok {
+				h = &hostAgg{}
+				agg[t.Config.Host] = h
 			}
-		}
-
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+			h.hasActive = true
+			if t.Status == models.TaskRunning {
+				h.activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						h.hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
 
+	var stats []models.HostStats
+	for host, limiter := range qm.limiters {
+		h, ok := agg[host]
+		if ok && h.hasActive {
+			curr, max, lat := limiter.GetStats()
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    h.activeCount,
+				TotalSpeedKBps: h.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 What: Refactored `QueueManager.GetHostStats()` to pre-aggregate active task metrics in a single `O(T)` loop before iterating over host limiters `O(H)`, replacing the nested `O(T*H)` iteration.
🎯 Why: `GetHostStats()` is called frequently via the `/api/stats` endpoint. Running nested loops while holding `qm.mu.RLock()` creates severe lock contention, degrading application performance (blocking workers and other API endpoints).
📊 Impact: Changes the time complexity of the critical section from `O(T*H)` to `O(T+H)`, reducing CPU time spent in the lock significantly when there are multiple hosts and tasks.
🔬 Measurement: Run a simulated load on the application and verify that polling `/api/stats` has significantly lower latency and application lock contention is reduced. Test with `go test ./internal/queue` to verify behavioral correctness.

---
*PR created automatically by Jules for task [15555474389449410246](https://jules.google.com/task/15555474389449410246) started by @arumes31*