### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limiting on login endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Prevention:**
 1. Used a robust `escapeHTML` helper function in `ui/static/app.js` to encode HTML entities (`&`, `<`, `>`, `"`, `'`) before using them in DOM elements constructed via `innerHTML`.
 2. Replaced the standard password string comparison (`!=`) in `internal/api/server.go` with `subtle.ConstantTimeCompare` from the `crypto/subtle` package to ensure the comparison time is independent of the input contents.
+## 2024-05-25 - Rate Limiter Map Eviction Memory Protection
+**Vulnerability:** Unbounded map growth during active rate limiting could lead to memory exhaustion (DoS). Standard map inserts without checks would grow indefinitely on malicious inputs or distributed attacks where IP entropy is high.
+**Learning:** Simply checking `len(map) > limit` and skipping rate limiting or returning a generic error is insufficient because it bypasses security on new attackers or panics on nil objects. A bounded map must safely evict elements when full.
+**Prevention:** Always bound map-based memory trackers (like rate limiters) by implementing an eviction check *on insertion*. If full, safely evict inactive elements. If still full after that (extreme entropy), forcefully evict an arbitrary element to make room for the new one, ensuring bounded memory without blocking or crashing the application.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	pathpkg "path"
@@ -26,6 +27,20 @@ import (
 var (
 	sessions   = make(map[string]bool)
 	sessionsMu sync.RWMutex
+)
+
+type loginAttempt struct {
+	count        int
+	blockedUntil time.Time
+	lastAttempt  time.Time
+}
+
+var (
+	loginAttempts      = make(map[string]*loginAttempt)
+	loginAttemptsMu    sync.Mutex
+	maxLoginAttempts   = 5
+	loginBlockDuration = 15 * time.Minute
+	maxLimiterEntries  = 1000
 )
 
 func generateToken() (string, error) {
@@ -166,10 +181,75 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 			return
 		}
 
+		ip, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			ip = r.RemoteAddr
+		}
+		if config.TrustProxy && r.Header.Get("X-Forwarded-For") != "" {
+			ips := strings.Split(r.Header.Get("X-Forwarded-For"), ",")
+			if len(ips) > 0 {
+				ip = strings.TrimSpace(ips[0])
+			}
+		}
+
+		loginAttemptsMu.Lock()
+		attempt, exists := loginAttempts[ip]
+		if !exists {
+			if len(loginAttempts) >= maxLimiterEntries {
+				now := time.Now()
+				for k, v := range loginAttempts {
+					if now.After(v.blockedUntil) && now.Sub(v.lastAttempt) > 15*time.Minute {
+						delete(loginAttempts, k)
+					}
+				}
+				if len(loginAttempts) >= maxLimiterEntries {
+					for k := range loginAttempts {
+						delete(loginAttempts, k)
+						break
+					}
+				}
+			}
+			attempt = &loginAttempt{}
+			loginAttempts[ip] = attempt
+		}
+		attempt.lastAttempt = time.Now()
+
+		isBlocked := time.Now().Before(attempt.blockedUntil)
+		loginAttemptsMu.Unlock()
+
+		if isBlocked {
+			http.Error(w, "Too many login attempts. Please try again later.", http.StatusTooManyRequests)
+			return
+		}
+
 		if subtle.ConstantTimeCompare([]byte(loginReq.Password), []byte(config.AuthPassword)) != 1 {
+			loginAttemptsMu.Lock()
+			currentAttempt, exists := loginAttempts[ip]
+			if !exists {
+				currentAttempt = &loginAttempt{}
+				loginAttempts[ip] = currentAttempt
+			}
+
+			// Reset attempt count if the previous ban expired
+			if time.Now().After(currentAttempt.blockedUntil) && currentAttempt.count >= maxLoginAttempts {
+				currentAttempt.count = 0
+			}
+
+			currentAttempt.count++
+			currentAttempt.lastAttempt = time.Now()
+
+			if currentAttempt.count >= maxLoginAttempts {
+				currentAttempt.blockedUntil = time.Now().Add(loginBlockDuration)
+			}
+			loginAttemptsMu.Unlock()
+
 			http.Error(w, "Invalid password", http.StatusUnauthorized)
 			return
 		}
+
+		loginAttemptsMu.Lock()
+		delete(loginAttempts, ip)
+		loginAttemptsMu.Unlock()
 
 		token, err := generateToken()
 		if err != nil {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `/api/login` endpoint lacked rate limiting, allowing attackers to perform unlimited brute-force password guessing attempts or credential stuffing attacks.
🎯 **Impact:** An attacker could eventually guess the password and gain unauthorized access to the application, or cause excessive server load.
🔧 **Fix:** Implemented an in-memory, bounded rate limiter. It extracts the client IP (respecting reverse proxies via `X-Forwarded-For`), tracks failed login attempts, and blocks IPs for 15 minutes after 5 consecutive failures. The underlying map is strictly bounded to 1,000 entries with a garbage collection eviction strategy to prevent memory exhaustion DoS attacks on the rate limiter itself.
✅ **Verification:** Verify that repeated failed logins return a `429 Too Many Requests` error and that the application builds and tests pass successfully.

---
*PR created automatically by Jules for task [8304392837938279226](https://jules.google.com/task/8304392837938279226) started by @arumes31*