### PR TITLE
🎨 Palette: Improve table accessibility with contextual labels and tooltips

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Preserving Button Icons & Providing Inline Loading States
 **Learning:** Overwriting the entire `.textContent` of a button that contains an inline icon (like `<svg>`) accidentally destroys the icon. Furthermore, users often lack immediate feedback on buttons like "Connect" or "Upload" while the action is processing, making the UI feel unresponsive even if a toast appears.
 **Action:** Always wrap button text in a `<span class="btn-text">` when the button also contains an SVG icon. Create a reusable `toggleButtonLoading` utility that toggles visibility between the static icon and a spinner icon, and temporarily updates the `.btn-text` content to reflect the loading state (e.g., "Connecting...").
+
+## 2026-05-31 - Add contextual ARIA labels to dynamic tables
+**Learning:** For dynamic tables containing actionable rows (e.g. file lists with checkboxes, queue tasks with action buttons), screen readers do not provide adequate context for the elements if they share identical visual text or lack text entirely. Adding a context-specific `aria-label` (e.g. "Select [filename]") or explicit `title` attributes on disabled fields ensures users relying on assistive technology understand what action corresponds to which row.
+**Action:** When adding interactive elements like checkboxes or inline buttons to data tables, always dynamically inject contextual details into the `aria-label` or `title` attributes.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = "Directories cannot be selected directly";
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {
@@ -1400,6 +1404,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
                     controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.setAttribute('aria-label', task.status === 'Paused' ? `Resume ${task.file_name}` : `Pause ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1407,6 +1412,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1414,6 +1420,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 **What:** 
- Added dynamically generated `aria-label` attributes (e.g., "Select [filename]") to checkboxes in the local file list.
- Added a `title` tooltip to disabled directory checkboxes explaining that directories cannot be selected directly.
- Added dynamic `aria-label` attributes to the Pause, Resume, Retry, and Remove buttons in the queue table (e.g., "Pause [filename]").
- Recorded a journal entry in `.Jules/palette.md` noting the importance of contextual labels in data tables.

🎯 **Why:** 
- In dynamic tables with many identical actions (e.g., a "Remove" button on every row), screen readers read out "Remove button" without context, making it impossible to know which file the button applies to without surrounding DOM navigation.
- Mouse users attempting to click disabled checkboxes for folders lacked feedback on why the action was prevented.

📸 **Before/After:**
- *Before:* Screen reader reads "Checkbox" or "Remove". Folder checkboxes are disabled silently.
- *After:* Screen reader reads "Select document.pdf" or "Remove document.pdf". Hovering over a disabled folder checkbox shows "Directories cannot be selected directly".

♿ **Accessibility:** 
- Greatly enhances navigability and understanding for visually impaired users relying on screen readers or keyboard navigation to manage files and queues.

---
*PR created automatically by Jules for task [5135364462337527472](https://jules.google.com/task/5135364462337527472) started by @arumes31*