### PR TITLE
⚡ Bolt: Replace O(H*T) nested loops with O(H+T) map aggregation in GetHostStats

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2025-05-25 - Avoid O(N*M) nested loops in critical sections
+**Learning:** O(T*H) nested loops inside frequently polled API endpoints that hold a read-write lock (like `GetHostStats`) cause significant lock contention as the dataset grows, blocking workers and freezing the UI.
+**Action:** When gathering metrics from multiple lists or maps, pre-aggregate data in a single pass O(N) using a map, instead of iterating over the full list inside another loop.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,43 +489,56 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	// ⚡ Bolt: Pre-aggregate host metrics in a single O(T) pass to avoid O(T*H) nested loops
+	// 🎯 Why: GetHostStats is polled frequently by the frontend. The previous O(T*H) nested loops
+	// held the global QueueManager RWMutex for too long when there were many tasks and hosts,
+	// causing lock contention and UI freezing.
+	type hostAgg struct {
+		hasActiveTasks bool
+		activeCount    int
+		totalSpeedBps  float64
+	}
+	aggMap := make(map[string]*hostAgg)
+
+	for _, t := range qm.tasks {
+		host := t.Config.Host
+		agg, exists := aggMap[host]
+		if !exists {
+			agg = &hostAgg{}
+			aggMap[host] = agg
 		}
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			agg.hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				agg.activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						agg.totalSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
-
-			stats = append(stats, models.HostStats{
-				Host:           host,
-				LastLatencyMs:  lat.Milliseconds(),
-				CurrentLimitKB: curr,
-				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
-			})
 		}
+	}
+
+	var stats []models.HostStats
+	for host, limiter := range qm.limiters {
+		agg, exists := aggMap[host]
+		if !exists || !agg.hasActiveTasks {
+			continue
+		}
+
+		curr, max, lat := limiter.GetStats()
+
+		stats = append(stats, models.HostStats{
+			Host:           host,
+			LastLatencyMs:  lat.Milliseconds(),
+			CurrentLimitKB: curr,
+			MaxLimitKB:     max,
+			ActiveTasks:    agg.activeCount,
+			TotalSpeedKBps: agg.totalSpeedBps / 1024,
+		})
 	}
 	return stats
 }


### PR DESCRIPTION
💡 **What:** Refactored `GetHostStats()` in `internal/queue/manager.go` to pre-aggregate active task counts and calculate speed within a single loop over `qm.tasks` mapped by host, removing the inner loop entirely.
🎯 **Why:** `GetHostStats` is polled frequently (e.g., every 1 second) by the frontend. The previous nested loops executed $O(H \times T)$ iterations, holding the global QueueManager `RWMutex` the entire time. This caused lock contention, particularly blocking the worker scheduler and freezing the UI when there were many tasks in the queue.
📊 **Impact:** Reduces time complexity from $O(H \times T)$ to $O(H + T)$. Decreases read-lock hold duration significantly, improving concurrency and API endpoint responsiveness.
🔬 **Measurement:** Verified the code compiles, lints, and passes all existing test cases (`go test ./...`).

---
*PR created automatically by Jules for task [5634231106272061197](https://jules.google.com/task/5634231106272061197) started by @arumes31*