### PR TITLE
🎨 Palette: Improve file checkbox accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2026-06-01 - Contextual Attributes for Dynamic Interactive Table Elements
+**Learning:** When generating interactive elements like checkboxes inside a data table, users relying on screen readers lack context of what row the element corresponds to, and users encountering disabled elements may not know why they are disabled.
+**Action:** When creating dynamic interactive elements within tables, inject contextual details like the file name into the `aria-label` to provide context for screen readers, and set the `title` attribute on disabled elements to explain why they are inactive.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = "Directories cannot be selected directly";
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` attributes to the checkboxes in the local file list using the file's name, and added an explanatory `title` attribute to disabled checkboxes that represent directories.
🎯 Why: To provide critical context for screen reader users so they know what file each checkbox selects, and to inform visual users why they cannot click on a directory's checkbox.
♿ Accessibility: The changes add screen reader context to table-based checkbox inputs.

---
*PR created automatically by Jules for task [18135333263468497109](https://jules.google.com/task/18135333263468497109) started by @arumes31*