### PR TITLE
⚡ Bolt: Optimize GetHostStats to O(H+T)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2025-05-25 - Avoid O(N*M) nested loops inside frequently accessed mutex critical sections
+**Learning:** In a heavily polled API endpoint like `/api/stats`, executing nested loops iterating over tracking maps and arrays ($O(H \times T)$) inside a read lock creates significant read lock contention. This can inadvertently block write operations and background workers.
+**Action:** Extract map/array iterations into sequential, single-pass aggregations ($O(H + T)$) whenever possible to minimize the time spent holding the lock and improve performance.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,49 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
-			}
+	// ⚡ Bolt: Aggregate task stats by host in a single O(T) pass instead of O(H*T) nested loops
+	// This reduces read lock contention on the frequently polled /api/stats endpoint.
+	type hostTaskStats struct {
+		hasActiveTasks bool
+		activeCount    int
+		hostSpeedBps   float64
+	}
+	taskStatsByHost := make(map[string]*hostTaskStats)
+
+	for _, t := range qm.tasks {
+		hs, ok := taskStatsByHost[t.Config.Host]
+		if !ok {
+			hs = &hostTaskStats{}
+			taskStatsByHost[t.Config.Host] = hs
 		}
 
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			hs.hasActiveTasks = true
+			if t.Status == models.TaskRunning {
+				hs.activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						hs.hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
+
+	var stats []models.HostStats
+	for host, limiter := range qm.limiters {
+		hs, ok := taskStatsByHost[host]
+		if ok && hs.hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    hs.activeCount,
+				TotalSpeedKBps: hs.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 **What:** Replaced the $O(H \times T)$ nested loops inside `QueueManager.GetHostStats()` with an $O(T + H)$ single-pass map aggregation.

🎯 **Why:** The `GetHostStats()` method is called by the frequently polled `/api/stats` endpoint. Iterating over all tasks for every single host while holding a read/write mutex (`qm.mu.RLock()`) scales poorly as the number of active queues and tasks grows. This causes significant read lock contention, effectively blocking workers and other operations that need to mutate the queue state. 

📊 **Impact:** Reduces the time complexity inside the critical section from $O(H \times T)$ to $O(H + T)$. Decreases read lock duration, reducing UI jank and preventing background workers from being blocked when attempting to acquire a write lock during heavy polling.

🔬 **Measurement:** Verify that the UI dashboard's `Host Statistics` panel still correctly reports active task counts, bandwidth speeds, and limits, and ensure `go test ./...` passes.

---
*PR created automatically by Jules for task [9010112541473053359](https://jules.google.com/task/9010112541473053359) started by @arumes31*