### PR TITLE
🎨 Palette: Add contextual ARIA labels to dynamic tables

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Added Empty States for Queues and Lists
 **Learning:** Tables representing local file lists and background task queues that are initially empty appear broken to users if only headers are displayed. Providing explicit "empty state" messages confirms system status and avoids user confusion.
 **Action:** Always include empty states for lists/tables that may be empty, and style them consistently to be visually distinct (e.g., center alignment, italic, muted text).
+## 2026-06-03 - Adding context to dynamic table elements
+**Learning:** Found that dynamic elements in tables, such as row checkboxes or action buttons, lacked contextual details in their `aria-label` or `title` attributes, making them confusing for screen reader users as they all sounded identical (e.g. "checkbox", "Pause", "Remove").
+**Action:** When adding interactive elements like checkboxes or inline buttons to dynamic tables (e.g., file lists, task queues), dynamically inject contextual details like the file name into the `aria-label` or `title` attributes to provide adequate context for screen readers. Add `title` attributes on disabled elements to explicitly explain why they are inactive.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -976,7 +976,11 @@ document.addEventListener('DOMContentLoaded', () => {
             cb.className = 'file-checkbox';
             cb.dataset.path = fullRelPath;
             cb.dataset.name = file.name;
-            if (file.is_dir) cb.disabled = true;
+            cb.setAttribute('aria-label', `Select ${file.name}`);
+            if (file.is_dir) {
+                cb.disabled = true;
+                cb.title = 'Directories cannot be selected';
+            }
             if (queuedFiles.has(fullRelPath)) cb.checked = true;
 
             cb.addEventListener('click', (e) => {
@@ -1399,7 +1403,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (task.status === 'Pending' || task.status === 'Paused') {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
-                    controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    const actionLabel = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.textContent = actionLabel;
+                    controlBtn.setAttribute('aria-label', `${actionLabel} ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1407,6 +1413,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1414,6 +1421,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 **What**: Added dynamic `aria-label` attributes to file selection checkboxes and background queue task action buttons (Pause, Resume, Retry, Remove) that include the target file's name. Added `title` attributes to disabled directory checkboxes explaining why they are inactive.

🎯 **Why**: Previously, screen reader users experienced a poor UX because all checkboxes in a list sounded identical ("checkbox"), and all action buttons simply read "Pause" or "Remove" without indicating *which* file they pertained to. Injecting the file name solves this ambiguity and creates a much more navigable interface.

♿ **Accessibility**:
- `aria-label` on checkboxes: "Select filename.txt"
- `aria-label` on task actions: "Pause filename.txt"
- `title` on disabled inputs provides visual and hover-based context for why interaction is prevented.

---
*PR created automatically by Jules for task [15057519973185029605](https://jules.google.com/task/15057519973185029605) started by @arumes31*