### PR TITLE
⚡ Bolt: Optimize GetHostStats() queue loop to prevent lock contention

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Optimizing String Sorting Performance in Large Lists
 **Learning:** `String.prototype.localeCompare` is significantly slower (up to 40x) than using an initialized `Intl.Collator` instance when executed within tight loops like `Array.prototype.sort()`. This creates notable jank when sorting large arrays, such as a file list.
 **Action:** When sorting arrays of strings on the frontend, particularly lists that can grow large, initialize `Intl.Collator` once and reuse its `.compare()` method instead of calling `.localeCompare` directly on the strings.
+
+## 2026-06-04 - Pre-aggregate Task Stats Under Mutexes
+**Learning:** Running an O(T * H) nested loop under a `sync.RWMutex` to aggregate stats can cause high lock contention for frequently polled API endpoints (like `/api/stats`).
+**Action:** Pre-aggregate task data in a single O(T) pass into a map, and then iterate through the map in an O(H) pass to compute host stats. This brings the complexity down to O(T + H) and minimizes time spent under the read lock.

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -489,41 +489,44 @@ func (qm *QueueManager) GetHostStats() []models.HostStats {
 	qm.mu.RLock()
 	defer qm.mu.RUnlock()
 
-	var stats []models.HostStats
-	for host, limiter := range qm.limiters {
-		// Only report hosts that are actually relevant (have tasks)
-		hasActiveTasks := false
-		activeCount := 0
-		for _, t := range qm.tasks {
-			if t.Config.Host == host && (t.Status == models.TaskRunning || t.Status == models.TaskPending) {
-				hasActiveTasks = true
-				if t.Status == models.TaskRunning {
-					activeCount++
-				}
+	// Pre-aggregate task stats to avoid O(T*H) nested loop contention
+	type hostAgg struct {
+		activeCount  int
+		hostSpeedBps float64
+	}
+	aggs := make(map[string]*hostAgg)
+
+	for _, t := range qm.tasks {
+		if t.Status == models.TaskRunning || t.Status == models.TaskPending {
+			agg, exists := aggs[t.Config.Host]
+			if !exists {
+				agg = &hostAgg{}
+				aggs[t.Config.Host] = agg
 			}
-		}
-
-		if hasActiveTasks {
-			curr, max, lat := limiter.GetStats()
-
-			// Compute per-host total speed from running tasks
-			var hostSpeedBps float64
-			for _, t := range qm.tasks {
-				if t.Config.Host == host && t.Status == models.TaskRunning && t.StartedAt != nil && t.BytesUploaded > 0 {
+			if t.Status == models.TaskRunning {
+				agg.activeCount++
+				if t.StartedAt != nil && t.BytesUploaded > 0 {
 					elapsed := time.Since(*t.StartedAt).Seconds()
 					if elapsed > 0 {
-						hostSpeedBps += float64(t.BytesUploaded) / elapsed
+						agg.hostSpeedBps += float64(t.BytesUploaded) / elapsed
 					}
 				}
 			}
+		}
+	}
 
+	var stats []models.HostStats
+	for host, limiter := range qm.limiters {
+		agg, hasActiveTasks := aggs[host]
+		if hasActiveTasks {
+			curr, max, lat := limiter.GetStats()
 			stats = append(stats, models.HostStats{
 				Host:           host,
 				LastLatencyMs:  lat.Milliseconds(),
 				CurrentLimitKB: curr,
 				MaxLimitKB:     max,
-				ActiveTasks:    activeCount,
-				TotalSpeedKBps: hostSpeedBps / 1024,
+				ActiveTasks:    agg.activeCount,
+				TotalSpeedKBps: agg.hostSpeedBps / 1024,
 			})
 		}
 	}


### PR DESCRIPTION
💡 **What**: Replaces the $O(T \times H)$ nested loop under `qm.mu.RLock()` in `GetHostStats()` with a single $O(T)$ map aggregation followed by an $O(H)$ map iteration.

🎯 **Why**: The `/api/stats` endpoint is polled frequently (e.g., every second). When the queue is large (high $T$) and there are many host limiters (high $H$), holding the read/write mutex during a nested loop causes severe CPU usage and blockages for queue workers and other API interactions.

📊 **Impact**: Reduces lock hold time significantly. Complexity drops from $O(T \times H)$ to $O(T + H)$.

🔬 **Measurement**: Inspect the polling latency of `/api/stats` when there are >10,000 pending tasks. The response times will be much flatter, and other concurrent operations (like queueing files) will no longer block.

---
*PR created automatically by Jules for task [8050129022642393774](https://jules.google.com/task/8050129022642393774) started by @arumes31*