### PR TITLE
🎨 Palette: Add accessibility context to inline queue action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2026-06-05 - Adding accessibility to inline action buttons in dynamic queues
+**Learning:** Found that dynamically generated action buttons in the queue list (Pause, Resume, Retry, Remove) lacked `aria-label` and `title` attributes, making them inaccessible and lacking context for screen readers when managing multiple tasks.
+**Action:** Always inject contextual details like the file name into the `aria-label` or `title` attributes when adding interactive elements like buttons to dynamic tables (e.g., task queues) to provide adequate context for screen readers.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1431,6 +1431,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
                     controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.title = `${task.status === 'Paused' ? 'Resume' : 'Pause'} ${task.file_name}`;
+                    controlBtn.setAttribute('aria-label', `${task.status === 'Paused' ? 'Resume' : 'Pause'} ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1440,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.title = `Retry ${task.file_name}`;
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1449,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.title = `Remove ${task.file_name}`;
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes that include the `task.file_name` to the dynamically generated "Pause", "Resume", "Retry", and "Remove" action buttons in the background task queue list (`ui/static/app.js`).

🎯 **Why:** Previously, these buttons only read their text content (e.g., "Pause" or "Remove"). For screen reader users navigating a queue with multiple active items, or for sighted users hovering to understand an action on a truncated row, "Pause" lacks the necessary context of *what* is being paused. Injecting the file name directly into these attributes ensures clear, contextual actions.

📸 **Before/After:** The buttons functionally look identical, but now natively surface tooltips on hover (e.g., "Retry sample.txt") and provide correct accessibility hooks.

♿ **Accessibility:** Screen readers will now announce "Retry sample.txt" rather than simply "Retry", drastically improving navigation of the dynamic queue table.

---
*PR created automatically by Jules for task [15541488699550450493](https://jules.google.com/task/15541488699550450493) started by @arumes31*