### PR TITLE
⚡ Bolt: bypass filter on empty search condition

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2026-06-04 - Pre-aggregate Task Stats Under Mutexes
 **Learning:** Running an O(T * H) nested loop under a `sync.RWMutex` to aggregate stats can cause high lock contention for frequently polled API endpoints (like `/api/stats`).
 **Action:** Pre-aggregate task data in a single O(T) pass into a map, and then iterate through the map in an O(H) pass to compute host stats. This brings the complexity down to O(T + H) and minimizes time spent under the read lock.
+
+## 2026-06-07 - Conditionally bypass array filtering
+**Learning:** In vanilla JS frontends, blindly running array `.filter()` operations over large UI lists when the search or filter condition is empty introduces redundant O(N) iterations that can degrade render performance.
+**Action:** Conditionally bypass the `.filter()` operation when the filter string is empty to avoid unnecessary O(N) iterations over the data.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -929,9 +929,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Local Files ---
 
     const renderLocalFiles = () => {
-        // ⚡ Bolt: Filter files before sorting to improve performance.
-        // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list.
-        const filtered = localFilesList.filter(f => f.name.toLowerCase().includes(localFilter));
+        // ⚡ Bolt: Filter files before sorting to improve performance. Conditionally bypass filter if no search term.
+        // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list. Bypassing an empty filter avoids redundant O(N) iterations.
+        const filtered = localFilter ? localFilesList.filter(f => f.name.toLowerCase().includes(localFilter)) : localFilesList;
         const sorted = sortFiles(filtered, localSort.key, localSort.dir);
         updateSortHeaders('file-table', localSort);
         fileListBody.innerHTML = '';
@@ -1123,7 +1123,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Remote Files ---
 
     const renderRemoteFiles = () => {
-        const filtered = remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter));
+        // ⚡ Bolt: Conditionally bypass filter if no search term.
+        // 📊 Impact: Bypassing an empty filter avoids redundant O(N) iterations over the remote file list.
+        const filtered = remoteFilter ? remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter)) : remoteFilesList;
         const sorted = sortFiles(filtered, remoteSort.key, remoteSort.dir);
         updateSortHeaders('remote-file-table', remoteSort);
         remoteFileListBody.innerHTML = '';


### PR DESCRIPTION
💡 What: Conditionally bypass the `Array.prototype.filter()` operation in `renderLocalFiles` and `renderRemoteFiles` when the search input (`localFilter` or `remoteFilter`) is empty.

🎯 Why: Running `.filter()` when there is no search condition introduces a redundant O(N) iteration over the entire file list array, allocating a new identical array. For large directories, this blocks the main thread unnecessarily before the subsequent sorting operation.

📊 Impact: Eliminates O(N) redundant iteration and intermediate array allocation when rendering large local and remote directories without an active search filter.

🔬 Measurement: Profile the UI render cycle (e.g., in Chrome DevTools Performance tab) when navigating into a large directory or clearing the search input. The time spent in `renderLocalFiles` or `renderRemoteFiles` will be reduced as the intermediate `.filter()` callback execution is skipped entirely.

---
*PR created automatically by Jules for task [5344351359687870107](https://jules.google.com/task/5344351359687870107) started by @arumes31*