### PR TITLE
🎨 Palette: Add context to queue action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2026-03-05 - Accessibility of inline action buttons
+**Learning:** Found that dynamically generated action buttons in tables (e.g., Pause, Retry, Remove) lacked contextual details, causing screen readers and users relying on tooltips to lack clarity on which specific row (file) the action applied to.
+**Action:** When adding interactive elements like buttons to dynamic tables (e.g., task queues), dynamically inject contextual details like the file name into the `aria-label` or `title` attributes to provide adequate context for screen readers.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1429,8 +1429,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 tdActions.className = 'col-actions';
                 if (task.status === 'Pending' || task.status === 'Paused') {
                     const controlBtn = document.createElement('button');
+                    const actionLabel = task.status === 'Paused' ? 'Resume' : 'Pause';
                     controlBtn.className = 'action-btn';
-                    controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.textContent = actionLabel;
+                    controlBtn.setAttribute('aria-label', `${actionLabel} ${task.file_name}`);
+                    controlBtn.title = `${actionLabel} ${task.file_name}`;
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1441,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
+                        retryBtn.title = `Retry ${task.file_name}`;
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1450,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
+                remBtn.title = `Remove ${task.file_name}`;
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to dynamically generated inline action buttons in the Task Queue ("Pause", "Resume", "Retry", "Remove"), explicitly linking the action to the relevant `task.file_name`. Also documented this learning in `.jules/palette.md`.

🎯 **Why:** Previously, screen reader users navigating through the queue table would encounter generic buttons like "Retry" or "Remove" without context of which file the button operated on. By dynamically injecting the `file_name` into the `aria-label` and `title`, we ensure clear context for keyboard, screen reader, and hover-based mouse users.

📸 **Before/After:** No visual style changes, but hovering over the buttons now reveals a helpful native tooltip like "Retry vacation_photos.zip", and screen readers will announce the explicit file context.

♿ **Accessibility:** Solves a major context deficit for non-sighted users by adhering to ARIA button context best practices within data grids.

---
*PR created automatically by Jules for task [15466935419641817473](https://jules.google.com/task/15466935419641817473) started by @arumes31*