### PR TITLE
🎨 Palette: Add contextual ARIA labels and titles to queue action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Preserving Button Icons & Providing Inline Loading States
 **Learning:** Overwriting the entire `.textContent` of a button that contains an inline icon (like `<svg>`) accidentally destroys the icon. Furthermore, users often lack immediate feedback on buttons like "Connect" or "Upload" while the action is processing, making the UI feel unresponsive even if a toast appears.
 **Action:** Always wrap button text in a `<span class="btn-text">` when the button also contains an SVG icon. Create a reusable `toggleButtonLoading` utility that toggles visibility between the static icon and a spinner icon, and temporarily updates the `.btn-text` content to reflect the loading state (e.g., "Connecting...").
+
+## 2026-06-08 - Added contextual ARIA labels to dynamically generated action buttons
+**Learning:** Generic action buttons in lists or queues (e.g., "Remove", "Retry", "Resume") lack context for screen reader users and users navigating with keyboards or hovering. When these buttons are generated dynamically based on an underlying data model (like a queue task), appending the relevant data context (like the file name) to the button's `aria-label` and `title` attributes significantly improves accessibility and clarity.
+**Action:** Always inject contextual identifying information (like item names or IDs) into the `aria-label` and `title` of generic action buttons within dynamic lists or tables during their creation.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1430,7 +1430,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (task.status === 'Pending' || task.status === 'Paused') {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
-                    controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    const actionName = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.textContent = actionName;
+                    controlBtn.title = `${actionName} ${task.file_name}`;
+                    controlBtn.setAttribute('aria-label', `${actionName} ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1441,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.title = `Retry ${task.file_name}`;
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1450,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.title = `Remove ${task.file_name}`;
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 **What:** Added dynamic `title` and `aria-label` attributes to the inline action buttons (Pause/Resume, Retry, Remove) within the file transfer queue.

🎯 **Why:** Generic buttons like "Remove" or "Retry" provide poor user experience and accessibility when displayed in a list, as users (especially those using screen readers) cannot easily discern *which* item the action targets. 

📸 **Before/After:**
*   **Before:** Buttons only had generic text (e.g., `Remove`). Screen readers would just announce "Remove, button".
*   **After:** Buttons now have tooltips and ARIA labels containing the specific file name (e.g., `Remove failed_file.txt`). Screen readers will announce "Remove failed_file.txt, button".

♿ **Accessibility:** Significantly improves context for screen reader users and adds helpful tooltips for mouse users hovering over actions.

---
*PR created automatically by Jules for task [18147991909071364470](https://jules.google.com/task/18147991909071364470) started by @arumes31*