### PR TITLE
🎨 Palette: Add contextual ARIA labels to queue actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Preserving Button Icons & Providing Inline Loading States
 **Learning:** Overwriting the entire `.textContent` of a button that contains an inline icon (like `<svg>`) accidentally destroys the icon. Furthermore, users often lack immediate feedback on buttons like "Connect" or "Upload" while the action is processing, making the UI feel unresponsive even if a toast appears.
 **Action:** Always wrap button text in a `<span class="btn-text">` when the button also contains an SVG icon. Create a reusable `toggleButtonLoading` utility that toggles visibility between the static icon and a spinner icon, and temporarily updates the `.btn-text` content to reflect the loading state (e.g., "Connecting...").
+
+## 2025-05-18 - Added contextual ARIA labels to dynamic table buttons
+**Learning:** In dynamic data tables (like a queue or file list), generic action buttons like "Remove" or "Retry" lack context when announced by a screen reader. A screen reader user navigating through interactive elements might hear "Remove, button", "Remove, button", without knowing *what* is being removed.
+**Action:** When adding interactive elements like inline buttons to dynamic tables, dynamically inject contextual details (like the file name or task ID) into the `aria-label` to provide adequate context for screen readers.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1431,6 +1431,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
                     controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.setAttribute('aria-label', `${task.status === 'Paused' ? 'Resume' : 'Pause'} ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1439,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1447,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 **What**: Added dynamic, contextual `aria-label`s to the generic action buttons (Pause, Resume, Retry, Remove) inside the queue data table.
🎯 **Why**: When navigating through a dynamic data table, assistive technologies previously read out only "Resume, button" or "Remove, button", providing zero context about *which* task would be affected. By injecting the `task.file_name` into the `aria-label`, screen readers now announce the full context (e.g., "Remove failed_file.zip").
📸 **Before/After**: Visually identical. Changes are purely semantic in the DOM structure for assistive technologies.
♿ **Accessibility**: Directly improves the accessibility of the core task management queue by providing explicit, contextual names for interactive table elements, eliminating ambiguous controls.

---
*PR created automatically by Jules for task [4451327911182425836](https://jules.google.com/task/4451327911182425836) started by @arumes31*