### PR TITLE
🎨 Palette: Add contextual ARIA labels to queue action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,7 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+
+## 2024-06-10 - Dynamic Table Action Buttons Accessibility
+**Learning:** Generic action buttons (like "Remove" or "Retry") inside dynamic data tables lack context for screen reader users when navigated out of the table context.
+**Action:** Always inject contextual details (e.g., the specific file name) into the `aria-label` or `title` attributes of dynamically generated interactive elements to ensure adequate context.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1430,7 +1430,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (task.status === 'Pending' || task.status === 'Paused') {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
-                    controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    const actionText = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.textContent = actionText;
+                    controlBtn.title = `${actionText} ${task.file_name}`;
+                    controlBtn.setAttribute('aria-label', `${actionText} task for ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1441,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.title = `Retry ${task.file_name}`;
+                        retryBtn.setAttribute('aria-label', `Retry task for ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1450,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.title = `Remove ${task.file_name}`;
+                remBtn.setAttribute('aria-label', `Remove task for ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes with contextual file names to dynamically generated queue action buttons ("Pause/Resume", "Retry", "Remove").
🎯 Why: Generic buttons in dynamic data tables are confusing or completely useless when a screen reader announces them out of context. The hover tooltip also provides a helpful micro-UX polish.
📸 Before/After: Action buttons visually appear the same but have added title attributes on hover.
♿ Accessibility: Ensures that screen reader users can independently understand the context and purpose of interactive actions in the queue list.

---
*PR created automatically by Jules for task [6580995780766447897](https://jules.google.com/task/6580995780766447897) started by @arumes31*