### PR TITLE
⚡ Bolt: Conditionally bypass empty filters for UI lists

### DIFF
--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -929,9 +929,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Local Files ---
 
     const renderLocalFiles = () => {
-        // ⚡ Bolt: Filter files before sorting to improve performance.
-        // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list.
-        const filtered = localFilesList.filter(f => f.name.toLowerCase().includes(localFilter));
+        // ⚡ Bolt: Conditionally bypass array filtering when the search string is empty.
+        // 📊 Impact: Avoids redundant O(N) iterations over the entire list when no filter is applied.
+        const filtered = localFilter ? localFilesList.filter(f => f.name.toLowerCase().includes(localFilter)) : localFilesList;
         const sorted = sortFiles(filtered, localSort.key, localSort.dir);
         updateSortHeaders('file-table', localSort);
         fileListBody.innerHTML = '';
@@ -1123,7 +1123,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Remote Files ---
 
     const renderRemoteFiles = () => {
-        const filtered = remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter));
+        // ⚡ Bolt: Conditionally bypass array filtering when the search string is empty.
+        // 📊 Impact: Avoids redundant O(N) iterations over the entire list when no filter is applied.
+        const filtered = remoteFilter ? remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter)) : remoteFilesList;
         const sorted = sortFiles(filtered, remoteSort.key, remoteSort.dir);
         updateSortHeaders('remote-file-table', remoteSort);
         remoteFileListBody.innerHTML = '';


### PR DESCRIPTION
### 💡 What
Conditionally bypassed `Array.prototype.filter()` in `renderLocalFiles` and `renderRemoteFiles` when the search query strings (`localFilter`, `remoteFilter`) are empty.

### 🎯 Why
Bypassing `.filter()` on an empty string prevents an unnecessary $O(N)$ iteration over the entire array of files. Although `String.includes('')` is fast, generating a new array through `.filter()` creates memory pressure and CPU overhead that can cause slight UI jank when the file lists are exceptionally large.

### 📊 Impact
Reduces unnecessary array allocations and prevents $O(N)$ iterations when the directory is refreshed or re-sorted without an active search query applied.

### 🔬 Measurement
To verify, you can populate `test_data/` with thousands of mock files, start the server, and observe the render execution time via browser dev tools when clicking sort headers with and without the patch. The rendering time when the filter string is empty will be measurably faster.

---
*PR created automatically by Jules for task [7211159685842287593](https://jules.google.com/task/7211159685842287593) started by @arumes31*