### PR TITLE
🎨 Palette: Add contextual ARIA labels to queue action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2026-03-05 - Contextual details for dynamic table action buttons
+**Learning:** Generic inline action buttons like "Pause", "Resume", "Retry", or "Remove" in dynamic tables (like the background task queue) lack context for screen reader users because the visual row structure isn't always conveyed linearly.
+**Action:** When adding interactive inline buttons to dynamic tables, dynamically inject contextual details like the file name or row subject into the `aria-label` and `title` attributes to provide adequate context for screen readers and tooltips.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1430,7 +1430,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (task.status === 'Pending' || task.status === 'Paused') {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
-                    controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    const actionName = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.textContent = actionName;
+                    controlBtn.setAttribute('aria-label', `${actionName} upload for ${task.file_name}`);
+                    controlBtn.title = `${actionName} upload for ${task.file_name}`;
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1441,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', `Retry upload for ${task.file_name}`);
+                        retryBtn.title = `Retry upload for ${task.file_name}`;
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1450,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name} from queue`);
+                remBtn.title = `Remove ${task.file_name} from queue`;
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-label` and `title` attributes to the "Pause/Resume", "Retry", and "Remove" generic inline buttons within the task queue table.
🎯 **Why:** Generic action buttons (e.g., "Remove") inside dynamic lists or tables lack context for screen readers when navigated out of the row structure. Incorporating the `task.file_name` into the ARIA label ensures users know exactly what file their action applies to. The `title` attribute adds a helpful tooltip on hover for mouse users.
📸 **Before/After:** The visual layout is unchanged. Added tooltips (e.g., "Remove important_document.pdf from queue"). Screen readers now announce contextual details. 
♿ **Accessibility:** Solves WCAG 2.1 SC 4.1.2 Name, Role, Value by providing a context-specific accessible name for generic repeated buttons.

---
*PR created automatically by Jules for task [5676024925715318283](https://jules.google.com/task/5676024925715318283) started by @arumes31*