### PR TITLE
🎨 Palette: Add contextual ARIA labels to queue actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,7 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+
+## 2024-05-18 - Queue Action Context for Screen Readers
+**Learning:** In dynamic tables like the transfer queue, inline action buttons with generic text like "Remove" or "Retry" are announced to screen readers without context. This leads to confusion about *which* item is being acted upon.
+**Action:** Always inject contextual row details (such as the file name) into the `aria-label` and `title` attributes of dynamically created inline action buttons.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1429,15 +1429,20 @@ document.addEventListener('DOMContentLoaded', () => {
                 tdActions.className = 'col-actions';
                 if (task.status === 'Pending' || task.status === 'Paused') {
                     const controlBtn = document.createElement('button');
+                    const isPaused = task.status === 'Paused';
                     controlBtn.className = 'action-btn';
-                    controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
-                    controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
+                    controlBtn.textContent = isPaused ? 'Resume' : 'Pause';
+                    controlBtn.setAttribute('aria-label', `${isPaused ? 'Resume' : 'Pause'} ${task.file_name}`);
+                    controlBtn.title = `${isPaused ? 'Resume' : 'Pause'} ${task.file_name}`;
+                    controlBtn.addEventListener('click', () => controlTask(task.id, isPaused ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
                     if (task.local_file_exists) {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
+                        retryBtn.title = `Retry ${task.file_name}`;
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1450,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
+                remBtn.title = `Remove ${task.file_name}`;
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 What: Added the associated `task.file_name` to the `aria-label` and `title` of the dynamically generated Pause, Resume, Retry, and Remove buttons in the task queue table in `ui/static/app.js`.
🎯 Why: In dynamic data tables, inline action buttons with generic text like "Remove" are read aloud by screen readers without any context about the surrounding row. By dynamically injecting the file name, screen reader users now hear "Remove video.mp4" instead of just "Remove".
📸 Before/After: See generated Playwright test verification video and screenshots.
♿ Accessibility: This change specifically targets WCAG compliance by providing meaningful labels to icon or generic action buttons, significantly improving the experience for screen reader users navigating the queue.

---
*PR created automatically by Jules for task [12016031026714550653](https://jules.google.com/task/12016031026714550653) started by @arumes31*