### PR TITLE
🎨 Palette: Add contextual ARIA labels to queue table buttons

### DIFF
--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1430,7 +1430,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (task.status === 'Pending' || task.status === 'Paused') {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
-                    controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    const actionName = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.textContent = actionName;
+                    controlBtn.setAttribute('aria-label', `${actionName} task for ${task.file_name}`);
+                    controlBtn.title = `${actionName} task for ${task.file_name}`;
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1441,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', `Retry task for ${task.file_name}`);
+                        retryBtn.title = `Retry task for ${task.file_name}`;
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1450,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', `Remove task for ${task.file_name}`);
+                remBtn.title = `Remove task for ${task.file_name}`;
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
**💡 What**
Added dynamic `aria-label` and `title` attributes to the 'Pause/Resume', 'Retry', and 'Remove' buttons in the task queue table, dynamically interpolating the file name.

**🎯 Why**
Previously, a screen reader would only announce "Retry" or "Remove," which lacks context when there are multiple rows in the queue. Now it will read out exactly which file the action applies to (e.g., "Retry task for sample.txt"). This also provides helpful tooltips for mouse users.

**📸 Before/After**
*Before:* `<button class="action-btn">Remove</button>`
*After:* `<button class="action-btn" aria-label="Remove task for sample.txt" title="Remove task for sample.txt">Remove</button>`

**♿ Accessibility**
Improves screen reader context for repeated action buttons in a table layout.

---
*PR created automatically by Jules for task [10901252031838855554](https://jules.google.com/task/10901252031838855554) started by @arumes31*