### PR TITLE
⚡ Bolt: Bypass array .filter() when search is empty

### DIFF
--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -931,7 +931,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const renderLocalFiles = () => {
         // ⚡ Bolt: Filter files before sorting to improve performance.
         // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list.
-        const filtered = localFilesList.filter(f => f.name.toLowerCase().includes(localFilter));
+        // ⚡ Bolt: Conditionally bypass array .filter() operations when the search condition is empty.
+        // 📊 Impact: Saves redundant O(N) iterations over the UI list when no filter is applied.
+        const filtered = localFilter ? localFilesList.filter(f => f.name.toLowerCase().includes(localFilter)) : localFilesList;
         const sorted = sortFiles(filtered, localSort.key, localSort.dir);
         updateSortHeaders('file-table', localSort);
         fileListBody.innerHTML = '';
@@ -1123,7 +1125,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Remote Files ---
 
     const renderRemoteFiles = () => {
-        const filtered = remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter));
+        // ⚡ Bolt: Conditionally bypass array .filter() operations when the search condition is empty.
+        // 📊 Impact: Saves redundant O(N) iterations over the UI list when no filter is applied.
+        const filtered = remoteFilter ? remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter)) : remoteFilesList;
         const sorted = sortFiles(filtered, remoteSort.key, remoteSort.dir);
         updateSortHeaders('remote-file-table', remoteSort);
         remoteFileListBody.innerHTML = '';


### PR DESCRIPTION
💡 What: Conditionally bypassed the array `.filter()` operation when rendering the local and remote file lists if the search query is empty.

🎯 Why: Calling `.filter()` iteratively over large arrays to check if names include an empty string is redundant. It introduces unnecessary O(N) traversal and memory allocation on every UI render cycle.

📊 Impact: Saves redundant O(N) iterations over the UI list when no filter is applied, leading to reduced CPU overhead and smoother UI updates on large datasets.

🔬 Measurement: Observe lower execution time of `renderLocalFiles()` and `renderRemoteFiles()` when navigating large directory trees without an active search query. Verified functionality by visual inspection and test suite execution.

---
*PR created automatically by Jules for task [10959918915151236952](https://jules.google.com/task/10959918915151236952) started by @arumes31*