### PR TITLE
⚡ Bolt: Bypass redundant filter on empty search

### DIFF
--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -931,7 +931,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const renderLocalFiles = () => {
         // ⚡ Bolt: Filter files before sorting to improve performance.
         // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list.
-        const filtered = localFilesList.filter(f => f.name.toLowerCase().includes(localFilter));
+        // ⚡ Bolt: Bypass redundant filter operations when search is empty to improve rendering performance.
+        const filtered = localFilter ? localFilesList.filter(f => f.name.toLowerCase().includes(localFilter)) : localFilesList;
         const sorted = sortFiles(filtered, localSort.key, localSort.dir);
         updateSortHeaders('file-table', localSort);
         fileListBody.innerHTML = '';
@@ -1123,7 +1124,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Remote Files ---
 
     const renderRemoteFiles = () => {
-        const filtered = remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter));
+        // ⚡ Bolt: Bypass redundant filter operations when search is empty to improve rendering performance.
+        // 📊 Impact: Saves O(N) iterations and memory allocations for large directories when no filter is active.
+        const filtered = remoteFilter ? remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter)) : remoteFilesList;
         const sorted = sortFiles(filtered, remoteSort.key, remoteSort.dir);
         updateSortHeaders('remote-file-table', remoteSort);
         remoteFileListBody.innerHTML = '';


### PR DESCRIPTION
### 💡 What
Conditionally skip the O(N) array `.filter()` operation when rendering local and remote file lists if the search filter is empty.

### 🎯 Why
When navigating large directories without an active search filter, the code previously iterated through the entire file list, executing a `toLowerCase()` string conversion and an `includes("")` check for every item, only to return an identical array. Bypassing this when the filter is empty avoids these redundant operations and the associated memory allocations (since `filter` creates a new array).

### 📊 Impact
Saves O(N) iterations, string conversions, and memory allocations for large directories when no filter is active, reducing unnecessary work on the main thread during rendering.

### 🔬 Measurement
Load a directory with a very large number of files. Ensure no search term is entered in the filter box. Rendering the list should perform fewer operations and avoid allocating a new array, resulting in slightly faster render times and less garbage collection pressure.

---
*PR created automatically by Jules for task [1516603544312911323](https://jules.google.com/task/1516603544312911323) started by @arumes31*