### PR TITLE
🎨 Palette: Add contextual ARIA labels to queue buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2026-03-05 - Accessibility of dynamic table buttons
+**Learning:** Generic button labels like 'Retry' or 'Remove' in dynamic tables (like task queues) lack context when read by a screen reader out of visual layout, making it difficult for users to know which row/item the button acts upon.
+**Action:** When creating interactive elements inside dynamic UI lists or tables, dynamically inject contextual details (such as the item's `file_name`) into the `aria-label` attribute (e.g., `aria-label="Remove task for file.txt"`) to provide adequate context for assistive technologies.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1431,6 +1431,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
                     controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.setAttribute('aria-label', `${task.status === 'Paused' ? 'Resume' : 'Pause'} upload for ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1439,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', `Retry upload for ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1447,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', `Remove task for ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-label` attributes to the control buttons (Pause/Resume, Retry, Remove) generated for each row in the task queue table within `ui/static/app.js`.

🎯 **Why:** Generic action buttons like "Remove" or "Retry" inside dynamic tables lack context when read by screen readers. A visually impaired user tabbing through the interface would just hear "Remove, button", without knowing *which* file the button acts upon.

📸 **Before/After:** Visually, the UI remains exactly the same. However, the DOM now includes elements like `<button aria-label="Remove task for file.txt">Remove</button>`.

♿ **Accessibility:** Significantly improves the keyboard and screen-reader experience by providing explicit context (`task.file_name`) for every action button in the queue list.

---
*PR created automatically by Jules for task [13792153324863509094](https://jules.google.com/task/13792153324863509094) started by @arumes31*