### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS memory exhaustion in rate limiter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,7 @@
 **Vulnerability:** Unbounded in-memory map tracking rate limiters (`qm.limiters`) per host allows a malicious user or numerous unauthenticated requests with unique hosts to exhaust server memory, leading to a Denial of Service (DoS).
 **Learning:** Maps used for state tracking (e.g., rate limiting, metrics) without eviction mechanisms represent a severe memory leak vector. Bounding and evicting items safely prevents this.
 **Prevention:** Implement safe map bounds and evictions. Evict inactive entries when exceeding a threshold (e.g., 100). When full and all entries are active, forceful eviction of an arbitrary/oldest entry must be used rather than throwing errors or skipping caching to maintain rate-limiting properties and bound memory.
+## 2025-02-27 - Rate Limiter DoS Vulnerability Fix
+**Vulnerability:** Memory exhaustion DoS risk in `loginAttempts` map rate limiter.
+**Learning:** The map size bounding logic was only executed when creating the *first* attempt, but if the password check failed and a new block was instantiated, the map was inserted into without bounds checking.
+**Prevention:** Centralize and abstract eviction/bounding logic to ensure it is systematically applied at every point a new entry is added to a bounded map.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -29,6 +29,23 @@ var (
 	sessionsMu sync.RWMutex
 )
 
+func evictLoginAttempts(loginAttempts map[string]*loginAttempt) {
+	if len(loginAttempts) >= maxLimiterEntries {
+		now := time.Now()
+		for k, v := range loginAttempts {
+			if now.After(v.blockedUntil) && now.Sub(v.lastAttempt) > 15*time.Minute {
+				delete(loginAttempts, k)
+			}
+		}
+		if len(loginAttempts) >= maxLimiterEntries {
+			for k := range loginAttempts {
+				delete(loginAttempts, k)
+				break
+			}
+		}
+	}
+}
+
 type loginAttempt struct {
 	count        int
 	blockedUntil time.Time
@@ -195,20 +212,7 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 		loginAttemptsMu.Lock()
 		attempt, exists := loginAttempts[ip]
 		if !exists {
-			if len(loginAttempts) >= maxLimiterEntries {
-				now := time.Now()
-				for k, v := range loginAttempts {
-					if now.After(v.blockedUntil) && now.Sub(v.lastAttempt) > 15*time.Minute {
-						delete(loginAttempts, k)
-					}
-				}
-				if len(loginAttempts) >= maxLimiterEntries {
-					for k := range loginAttempts {
-						delete(loginAttempts, k)
-						break
-					}
-				}
-			}
+			evictLoginAttempts(loginAttempts)
 			attempt = &loginAttempt{}
 			loginAttempts[ip] = attempt
 		}
@@ -226,6 +230,7 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 			loginAttemptsMu.Lock()
 			currentAttempt, exists := loginAttempts[ip]
 			if !exists {
+				evictLoginAttempts(loginAttempts)
 				currentAttempt = &loginAttempt{}
 				loginAttempts[ip] = currentAttempt
 			}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Memory exhaustion DoS risk in the `loginAttempts` map rate limiter. The map size bounding logic was correctly implemented when an IP address first connected, but if the password check failed and a new block was dynamically instantiated, the new map entry was inserted without any bounds checking, allowing an attacker to infinitely fill the map.
🎯 **Impact:** An attacker could rapidly spoof IP addresses (or exploit the `X-Forwarded-For` header) and send failed login attempts to exhaust the server's memory, causing the application to crash.
🔧 **Fix:** Extracted the eviction and map bounding logic into a helper function `evictLoginAttempts()`, and applied it uniformly at all insertion points for the `loginAttempts` map.
✅ **Verification:** Visually verified the changes using `sed`, checked test coverage, and confirmed the Go codebase builds and passes all tests successfully.

---
*PR created automatically by Jules for task [12667508820239910149](https://jules.google.com/task/12667508820239910149) started by @arumes31*