### PR TITLE
⚡ Bolt: Bypass redundant filter on empty search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 ## 2026-06-04 - Pre-aggregate Task Stats Under Mutexes
 **Learning:** Running an O(T * H) nested loop under a `sync.RWMutex` to aggregate stats can cause high lock contention for frequently polled API endpoints (like `/api/stats`).
 **Action:** Pre-aggregate task data in a single O(T) pass into a map, and then iterate through the map in an O(H) pass to compute host stats. This brings the complexity down to O(T + H) and minimizes time spent under the read lock.
+## 2025-05-27 - Conditionally Bypass Filter on Empty Search
+**Learning:** Running `Array.prototype.filter()` on large arrays when the filter condition is empty causes redundant O(N) iterations, unnecessary memory allocations for the new array, and forces garbage collection, leading to performance degradation.
+**Action:** Always conditionally check if the filter criteria exists (e.g., if a search string is not empty) before invoking `.filter()`. If the condition is empty, return the original array reference to prevent redundant processing.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -929,9 +929,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Local Files ---
 
     const renderLocalFiles = () => {
-        // ⚡ Bolt: Filter files before sorting to improve performance.
-        // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list.
-        const filtered = localFilesList.filter(f => f.name.toLowerCase().includes(localFilter));
+        // ⚡ Bolt: Conditionally bypass filter on empty search to prevent redundant O(N) iterations
+        // 📊 Impact: Eliminates unnecessary array allocations and loops when search is empty
+        const filtered = localFilter ? localFilesList.filter(f => f.name.toLowerCase().includes(localFilter)) : localFilesList;
         const sorted = sortFiles(filtered, localSort.key, localSort.dir);
         updateSortHeaders('file-table', localSort);
         fileListBody.innerHTML = '';
@@ -1123,7 +1123,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Remote Files ---
 
     const renderRemoteFiles = () => {
-        const filtered = remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter));
+        // ⚡ Bolt: Conditionally bypass filter on empty search to prevent redundant O(N) iterations
+        // 📊 Impact: Eliminates unnecessary array allocations and loops when search is empty
+        const filtered = remoteFilter ? remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter)) : remoteFilesList;
         const sorted = sortFiles(filtered, remoteSort.key, remoteSort.dir);
         updateSortHeaders('remote-file-table', remoteSort);
         remoteFileListBody.innerHTML = '';


### PR DESCRIPTION
💡 **What:** Conditionally bypasses `Array.prototype.filter()` in `renderLocalFiles` and `renderRemoteFiles` when the filter string is empty.

🎯 **Why:** Running `.filter()` on the entire file list array when the search condition is empty (`""`) is a redundant O(N) operation. It creates a completely unnecessary copy of the array and forces subsequent garbage collection, leading to performance degradation, especially with large directories.

📊 **Impact:** Eliminates unnecessary O(N) array loops and memory allocations during render cycles when no search is active, significantly reducing CPU usage and GC pressure.

🔬 **Measurement:** Verify by typing in the search bar to ensure filtering still works correctly, and confirm the UI remains performant when the search input is cleared. In the console, measuring the execution time of `renderLocalFiles` before and after this change will show a drop in execution time for empty search strings.

---
*PR created automatically by Jules for task [859940800059114240](https://jules.google.com/task/859940800059114240) started by @arumes31*