### PR TITLE
🎨 Palette: Add contextual ARIA labels to queue action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
+## 2026-03-05 - Contextual Accessibility for Generic Action Buttons
+**Learning:** Generic action buttons like 'Retry', 'Remove', or 'Pause' in dynamic lists (like the task queue) can be completely ambiguous to screen reader users if they aren't uniquely identified. Adding context (like the file name) to their `aria-label` and `title` attributes solves this problem.
+**Action:** When creating dynamic lists with repetitive action buttons, inject contextual data (like `task.file_name`) into the `aria-label` and `title` attributes to provide specific, actionable information for screen readers and improve the micro-UX.
 ## 2026-03-05 - Adding accessibility to toggle buttons
 **Learning:** Found that layout toggles (`view-toggle-btn`) and view options (`compact-toggle`) missed dynamic ARIA attributes, leaving screen reader users without proper context of the current interface state.
 **Action:** When creating toggle buttons or dropdown buttons, always pair with `aria-pressed` or `aria-expanded` and `aria-haspopup` to properly convey state changes and control relationships.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1431,6 +1431,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
                     controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.setAttribute('aria-label', `${task.status === 'Paused' ? 'Resume' : 'Pause'} ${task.file_name}`);
+                    controlBtn.title = `${task.status === 'Paused' ? 'Resume' : 'Pause'} ${task.file_name}`;
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1440,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
+                        retryBtn.title = `Retry ${task.file_name}`;
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1449,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
+                remBtn.title = `Remove ${task.file_name}`;
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 **What:** Added contextual `aria-label` and `title` attributes (incorporating the file name) to generic action buttons ('Resume', 'Pause', 'Retry', 'Remove') in the dynamic task queue.
🎯 **Why:** Generic buttons in dynamic lists provide zero context to screen reader users (who just hear "Remove, Remove, Remove"). This small UX addition provides immediate context and a helpful tooltip for sighted users without altering the visual design.
📸 **Before/After:** No visual changes besides native tooltips when hovering over queue action buttons.
♿ **Accessibility:** Screen readers will now announce "Remove [filename]" instead of just "Remove", making the queue significantly more navigable and intuitive for users relying on assistive technology.

---
*PR created automatically by Jules for task [324856919485591348](https://jules.google.com/task/324856919485591348) started by @arumes31*