### PR TITLE
⚡ Bolt: Conditionally bypass filter when empty to avoid redundant O(N) iterations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -929,9 +929,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Local Files ---
 
     const renderLocalFiles = () => {
-        // ⚡ Bolt: Filter files before sorting to improve performance.
-        // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list.
-        const filtered = localFilesList.filter(f => f.name.toLowerCase().includes(localFilter));
+        // ⚡ Bolt: Bypass redundant array filtering when search filter is empty.
+        // 📊 Impact: Avoids O(N) array iteration and allocation when not searching.
+        const filtered = localFilter ? localFilesList.filter(f => f.name.toLowerCase().includes(localFilter)) : localFilesList;
         const sorted = sortFiles(filtered, localSort.key, localSort.dir);
         updateSortHeaders('file-table', localSort);
         fileListBody.innerHTML = '';
@@ -1123,7 +1123,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Remote Files ---
 
     const renderRemoteFiles = () => {
-        const filtered = remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter));
+        const filtered = remoteFilter ? remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter)) : remoteFilesList;
         const sorted = sortFiles(filtered, remoteSort.key, remoteSort.dir);
         updateSortHeaders('remote-file-table', remoteSort);
         remoteFileListBody.innerHTML = '';


### PR DESCRIPTION
💡 What: Conditionally bypasses the array `.filter()` operation when rendering the local and remote file lists if the search filter is empty.
🎯 Why: Running an empty string check via `toLowerCase().includes("")` across an entire list of files forces an O(N) iteration and unnecessarily allocates a new array. This slows down render times for large file lists.
📊 Impact: Avoids the O(N) array iteration and allocation when not actively searching, yielding faster default list renders.
🔬 Measurement: Verify by rendering large folders with an empty search filter; the redundant string-checking loop will be skipped.

---
*PR created automatically by Jules for task [7762007082578219243](https://jules.google.com/task/7762007082578219243) started by @arumes31*