### PR TITLE
🎨 Palette: Add required indicators to SFTP connection form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,7 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+
+## 2026-06-21 - Adding visual required indicators to HTML5 required fields
+**Learning:** Found that required form fields using HTML5 `required` attributes do not always have an explicit visual indication (like an asterisk), causing confusion for users relying on visual cues.
+**Action:** Always complement HTML5 `required` attributes with a visual indicator, properly styled, and hidden from screen readers using `aria-hidden="true"`.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
💡 **What:** Added a visual asterisk (`*`) indicator to the `Host / IP Address`, `Port`, and `Username` fields in the SFTP connection form.
🎯 **Why:** These fields enforce input validation via the HTML5 `required` attribute. However, this rule was previously hidden from users until they attempted to submit the form, which could be frustrating. Adding an explicit visual indicator clarifies expectations upfront and improves form usability.
📸 **Before/After:** The connection form now explicitly denotes required fields with a red asterisk complementing the label text.
♿ **Accessibility:** The newly added asterisks are wrapped in a `<span>` element utilizing the `aria-hidden="true"` attribute. Since screen readers will already announce these inputs as required due to the underlying `required` HTML5 attribute, this prevents a redundant and potentially confusing double announcement of "asterisk required" or "star required".

---
*PR created automatically by Jules for task [2712477467297142723](https://jules.google.com/task/2712477467297142723) started by @arumes31*