### PR TITLE
🎨 Palette: Add visual indicators for required form fields

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-04-24 - Preserving Button Icons & Providing Inline Loading States
 **Learning:** Overwriting the entire `.textContent` of a button that contains an inline icon (like `<svg>`) accidentally destroys the icon. Furthermore, users often lack immediate feedback on buttons like "Connect" or "Upload" while the action is processing, making the UI feel unresponsive even if a toast appears.
 **Action:** Always wrap button text in a `<span class="btn-text">` when the button also contains an SVG icon. Create a reusable `toggleButtonLoading` utility that toggles visibility between the static icon and a spinner icon, and temporarily updates the `.btn-text` content to reflect the loading state (e.g., "Connecting...").
+
+## 2026-06-22 - Added visual indicators to required form fields
+**Learning:** HTML5 `required` attributes alone are insufficient for providing visual cues to sighted users. Adding explicit required field indicators, while ensuring they remain hidden from screen readers via `aria-hidden="true"`, significantly improves form usability without degrading the screen reader experience.
+**Action:** Always complement HTML5 `required` attributes on form elements with visible asterisks explicitly hidden from screen readers to enhance UX.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
💡 **What**: Added visual asterisks (`*`) next to the labels for the required form fields (`Host`, `Port`, `Username`) in the SFTP connection config panel.
🎯 **Why**: HTML5 `required` attributes are great for validation, but relying on them alone doesn't provide a clear, upfront visual cue to sighted users about which fields are mandatory before submission.
📸 **Before/After**: See visual verification screenshots. 
♿ **Accessibility**: Used `<span style="color: var(--error);" aria-hidden="true">*</span>` to hide the asterisk from screen readers to prevent redundant announcements, since the `<input>` elements already use the native `required` attribute.

---
*PR created automatically by Jules for task [5428896917823520973](https://jules.google.com/task/5428896917823520973) started by @arumes31*