### PR TITLE
🎨 Palette: Add visual indicators to required form fields

### DIFF
--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
💡 What: Added visual required indicators (asterisks) to the Host, Port, and Username fields on the connection form.
🎯 Why: Required fields should be visually distinct to help users understand form requirements before submission.
📸 Before/After: Visual asterisks now appear next to required fields.
♿ Accessibility: Used `aria-hidden="true"` on the asterisks to prevent redundant/confusing announcements by screen readers, which already announce the `required` attribute present on the corresponding inputs.

---
*PR created automatically by Jules for task [11712964629717748020](https://jules.google.com/task/11712964629717748020) started by @arumes31*