### PR TITLE
🎨 Palette: Add visual indicators to required form fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2026-03-05 - Visual indicators for required fields
+**Learning:** Found that relying solely on the HTML5 `required` attribute for form fields leaves visual users without a clear, immediate indication of which fields are mandatory until they attempt to submit.
+**Action:** When using HTML5 `required` attributes on form fields, complement them with an explicit visual indicator (like an asterisk) hidden from screen readers using `aria-hidden="true"` to aid visual users without causing redundant announcements.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
💡 What: Added explicit asterisk indicators next to the labels for required form fields (Host, Port, Username) in the SFTP Connection panel.
🎯 Why: Relying solely on the HTML5 `required` attribute leaves visual users without a clear, immediate indication of which fields are mandatory until they attempt to submit the form.
📸 Before/After: Visual asterisks now appear next to required fields.
♿ Accessibility: The added asterisks are hidden from screen readers using `aria-hidden="true"` to prevent redundant announcements, as the `required` attribute already conveys this information semantically.

---
*PR created automatically by Jules for task [18207829489511399641](https://jules.google.com/task/18207829489511399641) started by @arumes31*