### PR TITLE
🎨 Palette: Add contextual ARIA labels to queue action buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2026-06-26 - Adding contextual aria-labels to dynamic inline action buttons
+**Learning:** Found that inline action buttons (like "Remove", "Retry", "Pause") dynamically generated for each item in a list or queue (e.g., the background task queue) lacked contextual `aria-label`s. Screen reader users navigating by interactive elements would only hear the generic action name without knowing which file it applies to.
+**Action:** When adding interactive elements like checkboxes or inline buttons to dynamic tables (e.g., file lists, task queues), dynamically inject contextual details like the file name into the `aria-label` or `title` attributes to provide adequate context for screen readers.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1431,6 +1431,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
                     controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.setAttribute('aria-label', `${task.status === 'Paused' ? 'Resume' : 'Pause'} ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1439,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1447,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` attributes to the inline action buttons ("Pause/Resume", "Retry", "Remove") in the background task queue list, explicitly including the `file_name` variable for context.

🎯 Why: Previously, when screen reader users navigated the dynamically generated task queue, they would only hear generic actions (e.g., "Button: Remove", "Button: Retry") without knowing which file the action applied to. Adding the filename provides essential context, eliminating ambiguity and making the interface accessible.

📸 Before/After:
Before: `<button class="action-btn">Remove</button>` -> "Remove"
After: `<button class="action-btn" aria-label="Remove important_document.pdf">Remove</button>` -> "Remove important_document.pdf"

♿ Accessibility: Significantly improves keyboard and screen reader navigation within dynamic tables by ensuring interactive elements provide full context independently.

---
*PR created automatically by Jules for task [4901111607380301891](https://jules.google.com/task/4901111607380301891) started by @arumes31*