### PR TITLE
🎨 Palette: Add visual indicators for required form fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2026-06-27 - Adding visual required indicators
+**Learning:** Found that required form inputs like Host, Port, and Username lacked visual indicators (like asterisks), which could confuse users about which fields must be filled out before attempting to connect. Adding HTML required attributes isn't enough for visual users.
+**Action:** When adding HTML5 `required` attributes to form fields, always complement them with an explicit visual indicator (like an asterisk). Hide this indicator from screen readers using `aria-hidden="true"` to avoid redundant announcements since the input itself is already marked as required.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
💡 **What:** Added a visual asterisk (`*`) indicator to the labels of the required connection form fields (Host, Port, and Username).

🎯 **Why:** While the inputs already had the HTML5 `required` attribute, there was no visual cue for sighted users indicating which fields were mandatory before clicking "Connect". This could lead to confusion or validation errors upon submission. Adding a clear visual indicator improves form completion confidence and overall usability.

📸 **Before/After:**
*   **Before:** Labels appeared standard (e.g., "Host / IP Address").
*   **After:** Labels now feature a visual required indicator colored with the theme's error variable (e.g., "Host / IP Address *").

♿ **Accessibility:** The asterisk indicator is wrapped in a `span` with `aria-hidden="true"`. This ensures that screen readers, which already announce the `required` state based on the input attribute, do not redundantly read out "star" or "asterisk" when navigating the label, providing a cleaner auditory experience.

---
*PR created automatically by Jules for task [16087885741460495837](https://jules.google.com/task/16087885741460495837) started by @arumes31*