### PR TITLE
🎨 Palette: Add visual indicators for required form fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2026-03-05 - Required field visual indicators
+**Learning:** Found that required HTML5 form fields relied solely on the `required` attribute without explicit visual indication (like an asterisk). This causes a poor experience for visual users who only discover a field is required upon failed submission.
+**Action:** Always complement HTML5 `required` attributes with an explicit visual indicator (like an asterisk) hidden from screen readers using `aria-hidden="true"` to aid visual users without causing redundant announcements.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
💡 What: Added explicit visual indicators (asterisks) to the labels of the required `host`, `port`, and `user` form fields.
🎯 Why: To improve usability for visual users by clearly indicating required fields before submission, preventing unexpected validation errors.
📸 Before/After: Asterisks are now displayed next to the respective labels.
♿ Accessibility: The visual asterisks are hidden from screen readers using `aria-hidden="true"` since standard HTML `required` attributes already inform them of the constraint.

---
*PR created automatically by Jules for task [7302450355654190444](https://jules.google.com/task/7302450355654190444) started by @arumes31*