### PR TITLE
🎨 Palette: Add contextual ARIA labels to queue action buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2026-03-05 - Add contextual ARIA labels to queue action buttons
+**Learning:** Found that generic action buttons (like "Resume", "Retry", "Remove") dynamically generated for tasks in background queues lacked context for screen readers. When focused, they only announced the generic action without identifying which file or task they apply to.
+**Action:** When dynamically generating rows with inline action buttons in data tables or queues, always inject contextual identifiers (like the file name or row subject) into an `aria-label` attribute (e.g., `aria-label="Remove example.txt"`) to ensure actions are explicitly clear to screen reader users.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1431,6 +1431,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
                     controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.setAttribute('aria-label', `${task.status === 'Paused' ? 'Resume' : 'Pause'} ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1439,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1447,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 **What**: Added dynamic `aria-label` attributes to the inline action buttons (Resume, Pause, Retry, Remove) within the task queue in `ui/static/app.js`.

🎯 **Why**: When navigating the data table with a screen reader, generic buttons that only read "Remove" or "Retry" provide no context as to which file or task they belong to, making the interface confusing and inaccessible for keyboard/screen reader users.

📸 **Before/After**: Visually identical, but functionally contextual for screen readers.

♿ **Accessibility**: Significant improvement for screen reader users by providing explicit context (e.g., "Remove document.pdf" instead of just "Remove") for dynamically generated inline actions in a data table.

---
*PR created automatically by Jules for task [17893889097061136890](https://jules.google.com/task/17893889097061136890) started by @arumes31*