### PR TITLE
⚡ Bolt: Optimize large list rendering performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,10 @@
 ## 2026-06-04 - Pre-aggregate Task Stats Under Mutexes
 **Learning:** Running an O(T * H) nested loop under a `sync.RWMutex` to aggregate stats can cause high lock contention for frequently polled API endpoints (like `/api/stats`).
 **Action:** Pre-aggregate task data in a single O(T) pass into a map, and then iterate through the map in an O(H) pass to compute host stats. This brings the complexity down to O(T + H) and minimizes time spent under the read lock.
+## 2024-05-27 - Bypassing Redundant Array Allocations in Filters
+**Learning:** Calling `Array.prototype.filter()` with a condition that evaluates to true for all items (like `.includes('')` when a search input is empty) still unnecessarily allocates a completely new array, consuming memory and triggering GC pressure during frequent list renders.
+**Action:** When filtering lists based on optional search inputs in JavaScript, always conditionally bypass the `.filter()` operation if the search string is empty, assigning the original array reference instead to achieve O(1) assignment over O(N) allocation.
+
+## 2024-05-27 - Allocation-Free String Processing in Sort Comparators
+**Learning:** Using `String.prototype.split('.').pop()` inside sort comparators forces the JavaScript engine to allocate a new array on the heap for every single comparison (which happens $O(N \log N)$ times). This creates massive garbage collection overhead that slows down sorting of large lists.
+**Action:** When parsing strings (like file extensions) within tight loops or comparators, prefer allocation-free methods like `lastIndexOf` and `substring` to avoid heap allocations and improve performance.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -293,8 +293,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 case 'size':
                     return dirMul * ((a.size || 0) - (b.size || 0));
                 case 'type': {
-                    const extA = a.name.includes('.') ? a.name.split('.').pop().toLowerCase() : '';
-                    const extB = b.name.includes('.') ? b.name.split('.').pop().toLowerCase() : '';
+                    const dotA = a.name.lastIndexOf('.');
+                    const dotB = b.name.lastIndexOf('.');
+                    const extA = (dotA !== -1 && dotA !== 0) ? a.name.substring(dotA + 1).toLowerCase() : '';
+                    const extB = (dotB !== -1 && dotB !== 0) ? b.name.substring(dotB + 1).toLowerCase() : '';
                     return dirMul * basicCollator.compare(extA, extB);
                 }
                 default:
@@ -931,7 +933,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const renderLocalFiles = () => {
         // ⚡ Bolt: Filter files before sorting to improve performance.
         // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list.
-        const filtered = localFilesList.filter(f => f.name.toLowerCase().includes(localFilter));
+        // ⚡ Bolt: Avoid allocating a new filtered array if search filter is empty.
+        const filtered = localFilter ? localFilesList.filter(f => f.name.toLowerCase().includes(localFilter)) : localFilesList;
         const sorted = sortFiles(filtered, localSort.key, localSort.dir);
         updateSortHeaders('file-table', localSort);
         fileListBody.innerHTML = '';
@@ -1123,7 +1126,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Remote Files ---
 
     const renderRemoteFiles = () => {
-        const filtered = remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter));
+        // ⚡ Bolt: Avoid allocating a new filtered array if search filter is empty.
+        const filtered = remoteFilter ? remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter)) : remoteFilesList;
         const sorted = sortFiles(filtered, remoteSort.key, remoteSort.dir);
         updateSortHeaders('remote-file-table', remoteSort);
         remoteFileListBody.innerHTML = '';


### PR DESCRIPTION
💡 **What**: Replaced object-instantiating `split('.').pop()` logic in the sorting comparator with allocation-free `lastIndexOf` and `substring`. Additionally bypassed `.filter()` calls entirely when search inputs are empty.
🎯 **Why**: Calling `.split()` during an $O(N \log N)$ sort allocates arrays on the heap for every single comparison, causing massive garbage collection pressure and UI jank. Bypassing `.filter()` prevents redundant $O(N)$ array allocations when no search is active.
📊 **Impact**: Significantly reduces memory pressure and GC pauses during the rendering and sorting of large file lists.
🔬 **Measurement**: Verify by rendering a large directory and sorting by Type, or typing in and clearing the search filter while monitoring JS heap allocations via dev tools.

---
*PR created automatically by Jules for task [3864128365560195287](https://jules.google.com/task/3864128365560195287) started by @arumes31*