### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unbounded session map memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,8 @@
 **Vulnerability:** Unbounded in-memory map tracking rate limiters (`qm.limiters`) per host allows a malicious user or numerous unauthenticated requests with unique hosts to exhaust server memory, leading to a Denial of Service (DoS).
 **Learning:** Maps used for state tracking (e.g., rate limiting, metrics) without eviction mechanisms represent a severe memory leak vector. Bounding and evicting items safely prevents this.
 **Prevention:** Implement safe map bounds and evictions. Evict inactive entries when exceeding a threshold (e.g., 100). When full and all entries are active, forceful eviction of an arbitrary/oldest entry must be used rather than throwing errors or skipping caching to maintain rate-limiting properties and bound memory.
+
+## 2024-07-03 - Unbounded Session Map Memory Leak
+**Vulnerability:** The `sessions` map in `internal/api/server.go` was an unbounded `map[string]bool` where sessions were only deleted upon explicit logout. If users closed their browser without logging out, or if bots repeatedly attempted logins, the map would grow indefinitely, leading to a memory leak and potential DoS.
+**Learning:** Always implement time-based eviction and size limits for maps that track ephemeral data like sessions or rate limiting attempts.
+**Prevention:** Use `map[string]time.Time` to track session expiration and implement a periodic or access-time cleanup mechanism with a hard upper bound on map size.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	sessions   = make(map[string]bool)
+	sessions   = make(map[string]time.Time)
 	sessionsMu sync.RWMutex
 )
 
@@ -145,7 +145,8 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 				return
 			}
 			sessionsMu.RLock()
-			valid := sessions[cookie.Value]
+			exp, ok := sessions[cookie.Value]
+			valid := ok && time.Now().Before(exp)
 			sessionsMu.RUnlock()
 			if !valid {
 				logger.Warn(fmt.Sprintf("Auth failure: invalid or expired session token for %s", r.URL.Path))
@@ -257,7 +258,21 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 			return
 		}
 		sessionsMu.Lock()
-		sessions[token] = true
+		if len(sessions) >= 10000 {
+			now := time.Now()
+			for k, v := range sessions {
+				if now.After(v) {
+					delete(sessions, k)
+				}
+			}
+			if len(sessions) >= 10000 {
+				for k := range sessions {
+					delete(sessions, k)
+					break
+				}
+			}
+		}
+		sessions[token] = time.Now().Add(7 * 24 * time.Hour)
 		sessionsMu.Unlock()
 
 		http.SetCookie(w, &http.Cookie{
@@ -313,7 +328,8 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 				authenticated = false
 			} else {
 				sessionsMu.RLock()
-				authenticated = sessions[cookie.Value]
+				exp, ok := sessions[cookie.Value]
+				authenticated = ok && time.Now().Before(exp)
 				sessionsMu.RUnlock()
 			}
 		}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `sessions` map in `internal/api/server.go` was an unbounded `map[string]bool`. Sessions were only deleted upon explicit logout. If users closed their browser without logging out, or if bots repeatedly generated session tokens during login, the map would grow indefinitely, leading to a memory leak and a potential Denial of Service (DoS).
🎯 Impact: A malicious actor could easily exhaust the server's memory by repeatedly authenticating, causing the application to crash.
🔧 Fix: Refactored the `sessions` map to `map[string]time.Time` to track session expiration (set to 7 days). Implemented an eviction mechanism in the login handler that enforces a hard limit of 10,000 active sessions. When the limit is reached, expired sessions are pruned; if the map is still full, arbitrary sessions are evicted to guarantee memory bounds. Both the `withAuth` middleware and root handler now verify the expiration timestamp.
✅ Verification: Review the code changes in `internal/api/server.go` and run `go test ./...` to ensure no regressions. The unbounded map is now safely contained.

---
*PR created automatically by Jules for task [14402560834412877829](https://jules.google.com/task/14402560834412877829) started by @arumes31*