### PR TITLE
⚡ Bolt: Optimize file extension parsing in sort comparator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 ## 2026-06-04 - Pre-aggregate Task Stats Under Mutexes
 **Learning:** Running an O(T * H) nested loop under a `sync.RWMutex` to aggregate stats can cause high lock contention for frequently polled API endpoints (like `/api/stats`).
 **Action:** Pre-aggregate task data in a single O(T) pass into a map, and then iterate through the map in an O(H) pass to compute host stats. This brings the complexity down to O(T + H) and minimizes time spent under the read lock.
+## 2024-07-03 - Allocation-Free String Parsing
+**Learning:** In vanilla JS frontends, using `.split('.').pop()` to extract file extensions inside O(N log N) sorting comparators causes redundant array allocations, impacting performance on large datasets. Additionally, `idx !== -1 && idx !== 0` or `idx > 0` must be used with `lastIndexOf` to correctly handle dotfiles (e.g., `.env`), treating them as having no extension rather than incorrectly using the entire filename.
+**Action:** Replace object-instantiating methods like `.split().pop()` within comparators with allocation-free alternatives like `lastIndexOf` and `substring`. Ensure `idx > 0` is checked when parsing file extensions to handle dotfiles correctly.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -293,8 +293,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 case 'size':
                     return dirMul * ((a.size || 0) - (b.size || 0));
                 case 'type': {
-                    const extA = a.name.includes('.') ? a.name.split('.').pop().toLowerCase() : '';
-                    const extB = b.name.includes('.') ? b.name.split('.').pop().toLowerCase() : '';
+                    // ⚡ Bolt: Use allocation-free string parsing for file extensions.
+                    // 📊 Impact: Prevents array allocations in O(N log N) sorting, speeding up type sorts on large lists.
+                    const getExt = (name) => {
+                        const idx = name.lastIndexOf('.');
+                        return idx > 0 ? name.substring(idx + 1).toLowerCase() : '';
+                    };
+                    const extA = getExt(a.name);
+                    const extB = getExt(b.name);
                     return dirMul * basicCollator.compare(extA, extB);
                 }
                 default:


### PR DESCRIPTION
💡 What:
Replaced the `.split('.').pop()` string parsing logic in the frontend `sortFiles` comparator (specifically the 'type' sort switch case) with an allocation-free alternative utilizing `lastIndexOf` and `substring`.

🎯 Why:
The `sortFiles` function runs an `O(N log N)` sorting algorithm on the client side whenever a directory is loaded or re-sorted. Calling `.split()` inside a comparator function instantiates a new array in memory on every comparison evaluation, which creates significant garbage collection overhead and slows down sorting on very large directories.

📊 Impact:
Prevents $O(N \log N)$ redundant array allocations during sorting, significantly speeding up file rendering and type sorting on directories with thousands of files. As an added bonus, it introduces a fix for dotfiles (like `.env`) so they are now treated as having no extension rather than matching the whole filename, providing more accurate typing.

🔬 Measurement:
Start the frontend and inject thousands of dummy file objects into `localFilesList`, then click the "Type" table header to observe faster sort rendering without UI blocking or jank. Visual frontend validation was also completed via Playwright.

---
*PR created automatically by Jules for task [7682543921662328759](https://jules.google.com/task/7682543921662328759) started by @arumes31*