### PR TITLE
🎨 Palette: Add visual indicators to required form fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2026-04-10 - Required field visual indicators
+**Learning:** Found that required fields (using the HTML5 `required` attribute) lacked an explicit visual indicator, which could confuse sighted users.
+**Action:** When using HTML5 `required` attributes on form fields, always complement them with an explicit visual indicator (like an asterisk) hidden from screen readers using `aria-hidden="true"` to aid visual users without causing redundant announcements.

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
💡 What: Added red asterisks next to form fields (Host, Port, Username) that possess the HTML5 `required` attribute.
🎯 Why: Required form fields lacked explicit visual cues for sighted users.
📸 Before/After: Screenshot demonstrates the new asterisks visually aligning with the fields without breaking layout.
♿ Accessibility: Used `aria-hidden="true"` on the asterisks to ensure screen readers do not redundantly announce them since the inputs themselves already convey the `required` state.

---
*PR created automatically by Jules for task [12398693543992906328](https://jules.google.com/task/12398693543992906328) started by @arumes31*