### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure session management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,8 @@
 **Vulnerability:** Unbounded in-memory map tracking rate limiters (`qm.limiters`) per host allows a malicious user or numerous unauthenticated requests with unique hosts to exhaust server memory, leading to a Denial of Service (DoS).
 **Learning:** Maps used for state tracking (e.g., rate limiting, metrics) without eviction mechanisms represent a severe memory leak vector. Bounding and evicting items safely prevents this.
 **Prevention:** Implement safe map bounds and evictions. Evict inactive entries when exceeding a threshold (e.g., 100). When full and all entries are active, forceful eviction of an arbitrary/oldest entry must be used rather than throwing errors or skipping caching to maintain rate-limiting properties and bound memory.
+
+## 2026-07-04 - Unbounded Session Map
+**Vulnerability:** The in-memory `sessions` map stored boolean values and grew infinitely for every new login, without any mechanism to evict old or expired sessions, creating a Denial of Service (DoS) risk through memory exhaustion.
+**Learning:** In-memory session tracking maps without eviction logic will eventually leak memory in long-running services.
+**Prevention:** When implementing in-memory caching or session tracking maps, always include time-based expiration checks and eviction routines to ensure memory is bounded.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -25,8 +25,9 @@ import (
 )
 
 var (
-	sessions   = make(map[string]bool)
+	sessions   = make(map[string]time.Time)
 	sessionsMu sync.RWMutex
+	sessionTTL = 7 * 24 * time.Hour
 )
 
 type loginAttempt struct {
@@ -144,9 +145,13 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}
-			sessionsMu.RLock()
-			valid := sessions[cookie.Value]
-			sessionsMu.RUnlock()
+			sessionsMu.Lock()
+			expiry, valid := sessions[cookie.Value]
+			if valid && time.Now().After(expiry) {
+				delete(sessions, cookie.Value)
+				valid = false
+			}
+			sessionsMu.Unlock()
 			if !valid {
 				logger.Warn(fmt.Sprintf("Auth failure: invalid or expired session token for %s", r.URL.Path))
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
@@ -257,7 +262,14 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 			return
 		}
 		sessionsMu.Lock()
-		sessions[token] = true
+		now := time.Now()
+		// Clean up expired sessions periodically to prevent unbounded memory growth
+		for k, expiry := range sessions {
+			if now.After(expiry) {
+				delete(sessions, k)
+			}
+		}
+		sessions[token] = now.Add(sessionTTL)
 		sessionsMu.Unlock()
 
 		http.SetCookie(w, &http.Cookie{
@@ -312,9 +324,15 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 			if err != nil {
 				authenticated = false
 			} else {
-				sessionsMu.RLock()
-				authenticated = sessions[cookie.Value]
-				sessionsMu.RUnlock()
+				sessionsMu.Lock()
+				expiry, valid := sessions[cookie.Value]
+				if valid && time.Now().After(expiry) {
+					delete(sessions, cookie.Value)
+					authenticated = false
+				} else {
+					authenticated = valid
+				}
+				sessionsMu.Unlock()
 			}
 		}
 


### PR DESCRIPTION
🚨 Severity: HIGH (Denial of Service risk)
💡 Vulnerability: The in-memory `sessions` map stored boolean values and grew infinitely for every new login attempt, without any mechanism to evict old or expired sessions. This creates a Denial of Service (DoS) vulnerability via memory exhaustion over time. Additionally, sessions did not expire, allowing them to remain valid indefinitely.
🎯 Impact: Attackers or legitimate users logging in repeatedly over time could crash the server by exhausting its memory. Unexpired sessions could also be hijacked indefinitely if stolen.
🔧 Fix: Upgraded the `sessions` map to store `time.Time` instead of booleans. Enforced a 7-day TTL on new sessions. Sessions are validated against their expiration time upon each request, and expired sessions are opportunistically removed. Added a periodic cleanup during new logins to prevent unbounded map growth. 
✅ Verification: Tested via the local `go test ./...` suite and confirmed compilation and test success after patching.

---
*PR created automatically by Jules for task [7009139385370831266](https://jules.google.com/task/7009139385370831266) started by @arumes31*