### PR TITLE
🎨 Palette: Add contextual ARIA labels to queue buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,7 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+
+## 2026-07-05 - Add Contextual Context to Dynamic Actions
+**Learning:** Action buttons (like Pause, Retry, Remove) inside dynamic tables (like a task queue) lack context when read by a screen reader or hovered, because they look identical across rows. Generic buttons like 'Remove' are confusing without knowing *what* is being removed.
+**Action:** Dynamically inject contextual details (e.g., file names) into the `aria-label` or `title` attributes of action buttons generated in JavaScript to provide adequate context for screen readers and visual hover states.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1431,6 +1431,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
                     controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.title = `${task.status === 'Paused' ? 'Resume' : 'Pause'} ${task.file_name}`;
+                    controlBtn.setAttribute('aria-label', `${task.status === 'Paused' ? 'Resume' : 'Pause'} ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1440,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.title = `Retry ${task.file_name}`;
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1449,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.title = `Remove ${task.file_name}`;
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 What: Injected dynamic contextual labels (`task.file_name`) into the `aria-label` and `title` attributes of generic task queue action buttons (Pause, Resume, Retry, Remove).

🎯 Why: Generic buttons like "Remove" look identical across multiple rows in a dynamic table. This lack of context is confusing for visual users relying on tooltips and severely impacts screen reader users who cannot easily associate the button with its adjacent file name.

📸 Before/After:
Before:
`<button class="action-btn">Remove</button>` -> Screen reader: "Remove, button"

After:
`<button class="action-btn" aria-label="Remove my_video.mp4" title="Remove my_video.mp4">Remove</button>` -> Screen reader: "Remove my_video.mp4, button"

♿ Accessibility: Ensures that interactive actions in complex data tables are self-contained and descriptive, adhering to WCAG guidelines for button labeling and context.

---
*PR created automatically by Jules for task [11454683729345426161](https://jules.google.com/task/11454683729345426161) started by @arumes31*