### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure session management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,7 @@
 **Vulnerability:** Unbounded in-memory map tracking rate limiters (`qm.limiters`) per host allows a malicious user or numerous unauthenticated requests with unique hosts to exhaust server memory, leading to a Denial of Service (DoS).
 **Learning:** Maps used for state tracking (e.g., rate limiting, metrics) without eviction mechanisms represent a severe memory leak vector. Bounding and evicting items safely prevents this.
 **Prevention:** Implement safe map bounds and evictions. Evict inactive entries when exceeding a threshold (e.g., 100). When full and all entries are active, forceful eviction of an arbitrary/oldest entry must be used rather than throwing errors or skipping caching to maintain rate-limiting properties and bound memory.
+## 2024-07-06 - Missing Server-Side Session Expiration
+**Vulnerability:** The server maintained an unexpiring `sessions` map (`map[string]bool`). Session expiration was only enforced client-side via the `MaxAge` cookie attribute.
+**Learning:** An attacker could hijack an old session token and reuse it indefinitely, as the server never invalidated them over time or tracked their true expiry.
+**Prevention:** Implement time-based expiration for server-side sessions, storing tokens with an expiration timestamp (`map[string]time.Time`) and validating it upon each request.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	sessions   = make(map[string]bool)
+	sessions   = make(map[string]time.Time)
 	sessionsMu sync.RWMutex
 )
 
@@ -145,9 +145,9 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 				return
 			}
 			sessionsMu.RLock()
-			valid := sessions[cookie.Value]
+			expiry, valid := sessions[cookie.Value]
 			sessionsMu.RUnlock()
-			if !valid {
+			if !valid || time.Now().After(expiry) {
 				logger.Warn(fmt.Sprintf("Auth failure: invalid or expired session token for %s", r.URL.Path))
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
@@ -257,7 +257,7 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 			return
 		}
 		sessionsMu.Lock()
-		sessions[token] = true
+		sessions[token] = time.Now().Add(7 * 24 * time.Hour)
 		sessionsMu.Unlock()
 
 		http.SetCookie(w, &http.Cookie{
@@ -313,7 +313,8 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 				authenticated = false
 			} else {
 				sessionsMu.RLock()
-				authenticated = sessions[cookie.Value]
+				expiry, valid := sessions[cookie.Value]
+				authenticated = valid && time.Now().Before(expiry)
 				sessionsMu.RUnlock()
 			}
 		}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The backend `sessions` map (`map[string]bool`) lacked a time-based expiration mechanism. Session lifetime was solely reliant on the client-side cookie `MaxAge`.
🎯 Impact: An attacker who successfully hijacks a session token could theoretically reuse it indefinitely since the server never naturally invalidates the tokens based on age.
🔧 Fix: Updated the `sessions` tracker to store `time.Time` values representing the absolute expiration timestamp of the token (7 days from login, matching the cookie MaxAge). Validated the token age in all authorization checks.
✅ Verification: Tested via the unit test suite (`go test ./...`) to ensure standard authentication flows and invalidations still function correctly.

---
*PR created automatically by Jules for task [2913906314805001706](https://jules.google.com/task/2913906314805001706) started by @arumes31*