### PR TITLE
🎨 Palette: Add visual indicators to required fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2024-07-06 - Visual Indicators for Required Form Fields
+**Learning:** HTML5 `required` attributes do not provide sufficient visual cues for sighted users.
+**Action:** Always complement `required` attributes with an explicit visual indicator (like an asterisk) hidden from screen readers using `aria-hidden="true"` to aid visual users without causing redundant announcements.

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
💡 **What:** Added visual indicators (red asterisks) to the labels of required fields (Host, Port, Username) in the SFTP form.

🎯 **Why:** HTML5 `required` attributes provide validation but lack visual cues for sighted users. Adding explicit indicators prevents users from guessing which fields are mandatory before attempting to connect.

📸 **Before/After:**
*(Before)* Labels appeared as regular text (e.g., "Host / IP Address").
*(After)* Labels now feature a red asterisk (e.g., "Host / IP Address *").

♿ **Accessibility:** The added asterisks use `aria-hidden="true"` and `style="color: var(--error);"`. This ensures visual users receive the cue without causing redundant announcements for screen reader users, who already hear the native `required` state from the input element itself.

---
*PR created automatically by Jules for task [14228194311297593068](https://jules.google.com/task/14228194311297593068) started by @arumes31*