### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unbounded session map memory exhaustion (DoS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,8 @@
 **Vulnerability:** Unbounded in-memory map tracking rate limiters (`qm.limiters`) per host allows a malicious user or numerous unauthenticated requests with unique hosts to exhaust server memory, leading to a Denial of Service (DoS).
 **Learning:** Maps used for state tracking (e.g., rate limiting, metrics) without eviction mechanisms represent a severe memory leak vector. Bounding and evicting items safely prevents this.
 **Prevention:** Implement safe map bounds and evictions. Evict inactive entries when exceeding a threshold (e.g., 100). When full and all entries are active, forceful eviction of an arbitrary/oldest entry must be used rather than throwing errors or skipping caching to maintain rate-limiting properties and bound memory.
+
+## 2024-05-28 - Prevent DoS Memory Exhaustion in Session Map
+**Vulnerability:** Unbounded in-memory `sessions` map (`internal/api/server.go`) allowed an attacker to exhaust server memory by repeatedly calling the login endpoint with valid credentials, leading to a Denial of Service (DoS).
+**Learning:** Maps used for state tracking without eviction mechanisms represent a severe memory leak vector. Bounding and evicting items safely prevents this.
+**Prevention:** Track the last seen time of sessions and limit the size of the sessions map (e.g., to 1000). When the map reaches the maximum size, evict the oldest session.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -25,8 +25,9 @@ import (
 )
 
 var (
-	sessions   = make(map[string]bool)
-	sessionsMu sync.RWMutex
+	sessions    = make(map[string]time.Time)
+	maxSessions = 1000
+	sessionsMu  sync.RWMutex
 )
 
 type loginAttempt struct {
@@ -144,9 +145,12 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}
-			sessionsMu.RLock()
-			valid := sessions[cookie.Value]
-			sessionsMu.RUnlock()
+			sessionsMu.Lock()
+			_, valid := sessions[cookie.Value]
+			if valid {
+				sessions[cookie.Value] = time.Now()
+			}
+			sessionsMu.Unlock()
 			if !valid {
 				logger.Warn(fmt.Sprintf("Auth failure: invalid or expired session token for %s", r.URL.Path))
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
@@ -257,7 +261,17 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 			return
 		}
 		sessionsMu.Lock()
-		sessions[token] = true
+		if len(sessions) >= maxSessions {
+			var oldest string
+			var oldestTime time.Time
+			for k, v := range sessions {
+				if oldest == "" || v.Before(oldestTime) {
+					oldestTime, oldest = v, k
+				}
+			}
+			delete(sessions, oldest)
+		}
+		sessions[token] = time.Now()
 		sessionsMu.Unlock()
 
 		http.SetCookie(w, &http.Cookie{
@@ -312,9 +326,12 @@ func SetupApp(config models.Config, qm *queue.QueueManager) (*http.ServeMux, err
 			if err != nil {
 				authenticated = false
 			} else {
-				sessionsMu.RLock()
-				authenticated = sessions[cookie.Value]
-				sessionsMu.RUnlock()
+				sessionsMu.Lock()
+				_, authenticated = sessions[cookie.Value]
+				if authenticated {
+					sessions[cookie.Value] = time.Now()
+				}
+				sessionsMu.Unlock()
 			}
 		}
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,6 @@ func TestCoverageFlat(t *testing.T) {
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/files/download?path=../secret", nil))
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/files/download?path=a", nil))
 
-
 	// 6. SFTP Handlers (315-414)
 	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/test-connection", strings.NewReader("!")))
 	NewSFTPClient = func(req models.UploadRequest) SFTPClient {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The in-memory `sessions` map (`internal/api/server.go`) grows unboundedly as new users log in. A malicious actor could repeatedly call the login endpoint with valid credentials to exhaust server memory, leading to a Denial of Service (DoS) vulnerability.
🎯 Impact: An attacker could intentionally consume all server memory and cause the application to crash, denying access to all users. 
🔧 Fix: Bounded the `sessions` map size to a maximum of 1,000 entries using an LRU eviction strategy. Evict the oldest session when the limit is reached.
✅ Verification: Tested the application and examined map access patterns. The `sessions` map successfully bounded.

---
*PR created automatically by Jules for task [5173454364686221117](https://jules.google.com/task/5173454364686221117) started by @arumes31*