### PR TITLE
🎨 Palette: Add contextual ARIA labels and titles to queue action buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,7 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+
+## 2026-07-07 - Contextual ARIA labels for dynamic queue actions
+**Learning:** Screen readers announce generic 'Retry' or 'Remove' buttons in dynamic tables without context. Adding the file name to the aria-label and title makes them accessible and clear.
+**Action:** Dynamically inject contextual details into aria-label and title attributes for generated action buttons.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1431,6 +1431,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
                     controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.title = `${task.status === 'Paused' ? 'Resume' : 'Pause'} ${task.file_name}`;
+                    controlBtn.setAttribute('aria-label', `${task.status === 'Paused' ? 'Resume' : 'Pause'} ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1440,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.title = `Retry ${task.file_name}`;
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1449,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.title = `Remove ${task.file_name}`;
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 What: Dynamically injects `task.file_name` into the `aria-label` and `title` attributes of the "Pause", "Resume", "Retry", and "Remove" buttons generated in the queue table row.
🎯 Why: Screen readers announce generic generic button texts like "Retry" or "Remove" without context in dynamic tables. This provides explicit context to users relying on assistive technologies, and adds a helpful tooltip for visual users.
📸 Before/After: Visual UI remains the same, but hovering now reveals a specific tooltip (e.g. "Retry data_backup.zip") and screen readers will read the full context.
♿ Accessibility: Ensures generic table row action buttons have specific, contextual ARIA labels.

---
*PR created automatically by Jules for task [7787370305082308642](https://jules.google.com/task/7787370305082308642) started by @arumes31*