### PR TITLE
🎨 Palette: Add visual indicators for required fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ test_data/
 /api_cov
 /queue
 .Jules/
-.Jules
+
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2026-03-05 - Visual indicators for required fields
+**Learning:** Found that fields marked with `required` in HTML5 lacked a visual indicator, forcing visual users to guess which fields were mandatory before submitting.
+**Action:** When using HTML5 `required` attributes on form fields, complement them with an explicit visual indicator (like an asterisk colored with `var(--error)`) hidden from screen readers using `aria-hidden="true"` to aid visual users without causing redundant announcements.

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
💡 What: Added red asterisks next to labels for fields marked with the `required` HTML5 attribute.
🎯 Why: Visual users previously had to guess which fields (like Host, Port, and Username) were mandatory before form submission, which led to a poor user experience if they missed one and encountered HTML5 validation errors.
📸 Before/After: Added `*` indicators colored using the existing `var(--error)` CSS variable to the Host, Port, and Username labels.
♿ Accessibility: The added `<span>` tags containing the asterisks are explicitly hidden from screen readers using `aria-hidden="true"`. Since the corresponding `<input>` tags already have the `required` attribute, screen readers natively announce them as required; hiding the asterisks prevents redundant or confusing readouts (e.g., "star required").

---
*PR created automatically by Jules for task [7584127700714638397](https://jules.google.com/task/7584127700714638397) started by @arumes31*