### PR TITLE
⚡ Bolt: Bypass redundant array filtering on empty search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2026-06-04 - Pre-aggregate Task Stats Under Mutexes
 **Learning:** Running an O(T * H) nested loop under a `sync.RWMutex` to aggregate stats can cause high lock contention for frequently polled API endpoints (like `/api/stats`).
 **Action:** Pre-aggregate task data in a single O(T) pass into a map, and then iterate through the map in an O(H) pass to compute host stats. This brings the complexity down to O(T + H) and minimizes time spent under the read lock.
+
+## 2026-07-08 - Array filtering bypassing
+**Learning:** Passing an array through `.filter()` creates O(N) iterations and allocations, even if the condition returns true for every element (like an empty search string).
+**Action:** Conditionally bypass `.filter()` operations entirely if the search criteria is empty, just assigning the original array reference to prevent redundant processing.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -931,7 +931,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const renderLocalFiles = () => {
         // ⚡ Bolt: Filter files before sorting to improve performance.
         // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list.
-        const filtered = localFilesList.filter(f => f.name.toLowerCase().includes(localFilter));
+        // ⚡ Bolt: Bypass redundant array filtering on empty search
+        // 📊 Impact: Prevents O(N) redundant iteration and memory allocation when the search field is empty.
+        const filtered = localFilter === '' ? localFilesList : localFilesList.filter(f => f.name.toLowerCase().includes(localFilter));
         const sorted = sortFiles(filtered, localSort.key, localSort.dir);
         updateSortHeaders('file-table', localSort);
         fileListBody.innerHTML = '';
@@ -1123,7 +1125,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Remote Files ---
 
     const renderRemoteFiles = () => {
-        const filtered = remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter));
+        // ⚡ Bolt: Bypass redundant array filtering on empty search
+        // 📊 Impact: Prevents O(N) redundant iteration and memory allocation when the search field is empty.
+        const filtered = remoteFilter === '' ? remoteFilesList : remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter));
         const sorted = sortFiles(filtered, remoteSort.key, remoteSort.dir);
         updateSortHeaders('remote-file-table', remoteSort);
         remoteFileListBody.innerHTML = '';


### PR DESCRIPTION
💡 What: Bypasses the `.filter()` operation on local and remote file arrays when the search string is empty.
🎯 Why: Calling `.filter()` iterates over the entire array and allocates memory for a new array, even if the condition is functionally a no-op (like filtering on an empty string). For large directories, this adds up quickly, especially since it runs on every character typed or deleted.
📊 Impact: Prevents O(N) redundant iterations and memory allocations when rendering the full directory list.
🔬 Measurement: Verify by loading a directory with thousands of files and typing/clearing the search bar. The rendering when clearing the search bar should be visibly faster and consume less memory.

---
*PR created automatically by Jules for task [8389989012648076753](https://jules.google.com/task/8389989012648076753) started by @arumes31*