### PR TITLE
⚡ Bolt: Conditionally bypass array filter on empty search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2026-06-04 - Pre-aggregate Task Stats Under Mutexes
 **Learning:** Running an O(T * H) nested loop under a `sync.RWMutex` to aggregate stats can cause high lock contention for frequently polled API endpoints (like `/api/stats`).
 **Action:** Pre-aggregate task data in a single O(T) pass into a map, and then iterate through the map in an O(H) pass to compute host stats. This brings the complexity down to O(T + H) and minimizes time spent under the read lock.
+
+## 2026-07-09 - Conditionally bypass array filter on empty search
+**Learning:** In vanilla JS frontends, blindly running array `.filter()` operations over large UI lists when the search condition is empty causes redundant O(N) iterations and new array allocations on every render cycle.
+**Action:** Always conditionally bypass the filter logic (e.g., using a ternary `searchStr ? list.filter(...) : list`) to pass the original array reference directly to the sort/render logic when no search is active.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -929,9 +929,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Local Files ---
 
     const renderLocalFiles = () => {
-        // ⚡ Bolt: Filter files before sorting to improve performance.
-        // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list.
-        const filtered = localFilesList.filter(f => f.name.toLowerCase().includes(localFilter));
+        // ⚡ Bolt: Filter files before sorting to improve performance. Conditionally bypass filter when search is empty.
+        // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list. Avoids O(N) filter iterations when search is empty.
+        const filtered = localFilter ? localFilesList.filter(f => f.name.toLowerCase().includes(localFilter)) : localFilesList;
         const sorted = sortFiles(filtered, localSort.key, localSort.dir);
         updateSortHeaders('file-table', localSort);
         fileListBody.innerHTML = '';
@@ -1123,7 +1123,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Remote Files ---
 
     const renderRemoteFiles = () => {
-        const filtered = remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter));
+        // ⚡ Bolt: Conditionally bypass filter when search is empty.
+        // 📊 Impact: Avoids O(N) filter iterations and allocations on large file lists when no search term is entered.
+        const filtered = remoteFilter ? remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter)) : remoteFilesList;
         const sorted = sortFiles(filtered, remoteSort.key, remoteSort.dir);
         updateSortHeaders('remote-file-table', remoteSort);
         remoteFileListBody.innerHTML = '';


### PR DESCRIPTION
💡 **What:** Conditionally bypassed array `.filter()` operations in `renderLocalFiles` and `renderRemoteFiles` when the search strings (`localFilter` / `remoteFilter`) are empty.

🎯 **Why:** Blindly running `.filter()` on large file lists when no search term is entered causes redundant O(N) iterations, string lowercasing, `.includes()` checks, and creates new array allocations on every render cycle.

📊 **Impact:** Avoids unnecessary O(N) array iterations and memory allocations when rendering large file lists without an active search filter, directly passing the master array reference to the sort function instead.

🔬 **Measurement:** Render time profiling on folders containing thousands of files with an empty search box will show reduced garbage collection and faster render cycles.

---
*PR created automatically by Jules for task [6816173428786949847](https://jules.google.com/task/6816173428786949847) started by @arumes31*