### PR TITLE
🎨 Palette: Add explicit visual indicators for required fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,7 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+
+## 2024-05-24 - Required Field Indicators
+**Learning:** HTML5 required attributes alone don't provide sufficient visual cues for sighted users.
+**Action:** When using HTML5 `required` attributes on form fields, complement them with an explicit visual indicator (like an asterisk colored with `var(--error)`) hidden from screen readers using `aria-hidden="true"` to aid visual users without causing redundant announcements.

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
🎨 Palette: Add explicit visual indicators for required fields

💡 What: Appended an asterisk to the labels of required connection form fields.
🎯 Why: HTML5 `required` attributes do not provide a clear visual indication to sighted users before submitting the form.
📸 Before/After: Labels updated from "Host / IP Address" to "Host / IP Address *" (colored red).
♿ Accessibility: Used `aria-hidden="true"` on the asterisk to prevent redundant screen reader announcements, since the input itself already conveys the required state via the `required` attribute.

---
*PR created automatically by Jules for task [9012446030218583688](https://jules.google.com/task/9012446030218583688) started by @arumes31*