### PR TITLE
🎨 Palette: Add contextual ARIA labels to queue action buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,7 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+
+## 2026-07-10 - Generic action buttons in dynamic lists
+**Learning:** Found that generic action buttons (like Pause, Resume, Retry, Remove) inside dynamic lists/tables lack context for screen reader users and those relying on tooltips, causing ambiguity about what item the action applies to.
+**Action:** Always inject contextual information (e.g., the specific file name or task ID) into the `aria-label` and `title` attributes of generic action buttons within dynamic lists to ensure clarity and accessibility.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1431,6 +1431,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
                     controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.title = (task.status === 'Paused' ? 'Resume ' : 'Pause ') + task.file_name;
+                    controlBtn.setAttribute('aria-label', (task.status === 'Paused' ? 'Resume ' : 'Pause ') + task.file_name);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1440,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.title = 'Retry ' + task.file_name;
+                        retryBtn.setAttribute('aria-label', 'Retry ' + task.file_name);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1449,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.title = 'Remove ' + task.file_name;
+                remBtn.setAttribute('aria-label', 'Remove ' + task.file_name);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-label` and `title` attributes containing the `task.file_name` to the Pause/Resume, Retry, and Remove action buttons inside the task queue.

🎯 **Why:** To prevent ambiguity. When these generic buttons are listed in a table, users relying on screen readers or tooltips do not inherently know which file the action will apply to without surrounding context.

📸 **Before/After:**
- **Before:** Tooltip: "Remove". Screen reader: "Remove, button".
- **After:** Tooltip: "Remove vacation_photo.jpg". Screen reader: "Remove vacation_photo.jpg, button".

♿ **Accessibility:** This directly addresses WCAG criteria for providing descriptive labels for form controls and interactive elements, ensuring the purpose of each button is clear independently of its visual placement in the row.

---
*PR created automatically by Jules for task [1693576642937904268](https://jules.google.com/task/1693576642937904268) started by @arumes31*