### PR TITLE
⚡ Bolt: Bypass unnecessary array .filter() operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2026-06-04 - Pre-aggregate Task Stats Under Mutexes
 **Learning:** Running an O(T * H) nested loop under a `sync.RWMutex` to aggregate stats can cause high lock contention for frequently polled API endpoints (like `/api/stats`).
 **Action:** Pre-aggregate task data in a single O(T) pass into a map, and then iterate through the map in an O(H) pass to compute host stats. This brings the complexity down to O(T + H) and minimizes time spent under the read lock.
+
+## 2024-05-14 - Bypass Unnecessary Array Filters
+**Learning:** In vanilla JS frontends, unconditionally calling `.filter()` on large UI lists (like file lists) forces O(N) iterations and memory allocations for new arrays even when the search or filter condition is empty.
+**Action:** Conditionally execute array `.filter()` operations over large UI lists only when the filter condition evaluates to true to avoid redundant iterations and memory overhead.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -931,7 +931,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const renderLocalFiles = () => {
         // ⚡ Bolt: Filter files before sorting to improve performance.
         // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list.
-        const filtered = localFilesList.filter(f => f.name.toLowerCase().includes(localFilter));
+        // ⚡ Bolt: Conditionally execute `.filter()` only when filter is not empty.
+        // 📊 Impact: Avoids O(N) iterations and memory allocations when there is no filter.
+        const filtered = localFilter ? localFilesList.filter(f => f.name.toLowerCase().includes(localFilter)) : localFilesList;
         const sorted = sortFiles(filtered, localSort.key, localSort.dir);
         updateSortHeaders('file-table', localSort);
         fileListBody.innerHTML = '';
@@ -1123,7 +1125,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Remote Files ---
 
     const renderRemoteFiles = () => {
-        const filtered = remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter));
+        // ⚡ Bolt: Conditionally execute `.filter()` only when filter is not empty.
+        // 📊 Impact: Avoids O(N) iterations and memory allocations when there is no filter.
+        const filtered = remoteFilter ? remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter)) : remoteFilesList;
         const sorted = sortFiles(filtered, remoteSort.key, remoteSort.dir);
         updateSortHeaders('remote-file-table', remoteSort);
         remoteFileListBody.innerHTML = '';


### PR DESCRIPTION
**💡 What:** 
Modified `renderLocalFiles` and `renderRemoteFiles` in `ui/static/app.js` to conditionally execute `.filter()` on `localFilesList` and `remoteFilesList`. The `.filter()` method is now only called when `localFilter` or `remoteFilter` are not empty strings. If the filter is empty, it reuses the original array reference.

**🎯 Why:** 
In vanilla JS, unconditionally calling `.filter()` on large arrays forces O(N) iterations and allocates memory for a brand new array every single time, even if the filter condition is a no-op (like an empty search string). This causes unnecessary CPU usage, blocks the main thread longer than necessary, and increases memory garbage collection overhead, particularly when rendering large directories.

**📊 Impact:** 
- **O(N) iteration bypassed:** Avoids iterating through the entire list of files when no search filter is applied.
- **Reduced memory allocation:** Prevents the allocation of a new array containing all elements when no filter is active, reducing GC pressure.

**🔬 Measurement:** 
1. Open the UI.
2. Navigate to a directory with a large number of files.
3. Observe the rendering performance. 
4. Type in the local or remote search box. The filtering will execute exactly as before. When the box is cleared, the original list is restored without the `.filter()` overhead.

---
*PR created automatically by Jules for task [13180577779594299513](https://jules.google.com/task/13180577779594299513) started by @arumes31*