### PR TITLE
🎨 Palette: Add visual indicators to required form fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2026-07-11 - Accessibility of Required Form Fields
+**Learning:** Found that relying solely on HTML5 `required` attributes lacks visual clarity for users, but simply adding asterisks causes redundant announcements for screen reader users.
+**Action:** When using `required` attributes, always complement them with a visual indicator (like a red asterisk) hidden from screen readers using `aria-hidden="true"`.

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span class="required-indicator" aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span class="required-indicator" aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span class="required-indicator" aria-hidden="true" style="color: var(--error);">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
💡 **What**: Added visual asterisks (`*`) to the Host, Port, and Username fields in the SFTP configuration form.
🎯 **Why**: While HTML5 `required` attributes exist for these fields, there was no visual cue indicating they were mandatory, leading to potential confusion for sighted users who might attempt to submit the form without them.
📸 **Before/After**: Screenshots and videos demonstrating the visual asterisks were captured and verified during frontend testing.
♿ **Accessibility**: The asterisks are hidden from screen readers using `aria-hidden="true"`. This prevents screen readers from redundantly announcing "star" or "asterisk" when they already announce the field as "required" due to the HTML5 attribute, preserving a clean auditory experience while improving the visual one.

---
*PR created automatically by Jules for task [11835353718630484178](https://jules.google.com/task/11835353718630484178) started by @arumes31*