### PR TITLE
🎨 Palette: Add explicit visual indicators to required form fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2026-04-10 - Explicit visual indicators for required fields
+**Learning:** Found that relying solely on the HTML5 `required` attribute leaves visual users without a clear, upfront indication of which fields must be filled out before submitting a form.
+**Action:** When using HTML5 `required` attributes on form fields, always complement them with an explicit visual indicator (like an asterisk) hidden from screen readers using `aria-hidden="true"` to aid visual users without causing redundant announcements.

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
💡 What: Added a red asterisk to the labels of the `host`, `port`, and `user` inputs in the SFTP configuration form. The asterisks use the existing `--error` CSS variable for color and are hidden from screen readers via `aria-hidden="true"`.
🎯 Why: Relying solely on the HTML5 `required` attribute leaves visual users without a clear, upfront indication of which fields must be filled out before submitting a form. This prevents a frustrating "fill-in-and-fail" cycle.
📸 Before/After: Visual asterisks now appear next to required field labels.
♿ Accessibility: The visual indicators are intentionally hidden from screen readers using `aria-hidden="true"` to prevent redundant "required... asterisk" announcements, as the `required` attribute itself natively conveys this semantic meaning to assistive technologies.

---
*PR created automatically by Jules for task [12524247060779733196](https://jules.google.com/task/12524247060779733196) started by @arumes31*