### PR TITLE
🎨 Palette: Add contextual aria-labels to queue action buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,7 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+
+## 2026-07-13 - Contextual Labels in Dynamic Tables
+**Learning:** Generic action buttons (like 'Pause', 'Retry', 'Remove') within large dynamic lists or tables lack context for screen reader users and can be ambiguous even visually if row context isn't obvious.
+**Action:** Dynamically inject row-specific identifiers (e.g., `task.file_name`) into the `aria-label` and `title` attributes when creating these interactive elements to ensure clear, accessible functionality.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1431,6 +1431,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
                     controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.title = `${task.status === 'Paused' ? 'Resume' : 'Pause'} ${task.file_name}`;
+                    controlBtn.setAttribute('aria-label', `${task.status === 'Paused' ? 'Resume' : 'Pause'} ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1440,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.title = `Retry ${task.file_name}`;
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1449,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.title = `Remove ${task.file_name}`;
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
**💡 What:** 
Added dynamic, file-specific `aria-label` and `title` attributes to the Pause, Resume, Retry, and Remove buttons generated inside the background task queue table.

**🎯 Why:** 
Generic buttons (e.g., just "Remove" or "Retry") inside large data tables lack sufficient context for screen reader users and can be confusing even visually if the row association isn't immediately obvious. Injecting the `task.file_name` provides clear, unambiguous intent for each action.

**📸 Before/After:** 
- *Before:* `<button class="action-btn">Remove</button>`
- *After:* `<button class="action-btn" title="Remove test-file.mp4" aria-label="Remove test-file.mp4">Remove</button>`

**♿ Accessibility:** 
Significantly improves screen reader experience for the dynamic background queue. Tooltips are also enhanced for mouse users.

---
*PR created automatically by Jules for task [882558284547996733](https://jules.google.com/task/882558284547996733) started by @arumes31*