### PR TITLE
⚡ Bolt: [Performance] Bypass unnecessary array filtering when filter string is empty

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2026-06-04 - Pre-aggregate Task Stats Under Mutexes
 **Learning:** Running an O(T * H) nested loop under a `sync.RWMutex` to aggregate stats can cause high lock contention for frequently polled API endpoints (like `/api/stats`).
 **Action:** Pre-aggregate task data in a single O(T) pass into a map, and then iterate through the map in an O(H) pass to compute host stats. This brings the complexity down to O(T + H) and minimizes time spent under the read lock.
+
+## 2026-07-14 - Conditionally bypass array filtering
+**Learning:** In vanilla JS frontends, unconditionally running `.filter()` over large UI lists when the search condition is empty wastes O(N) iterations and memory allocations. Returning the original array reference via a ternary operator (e.g., `filterStr ? arr.filter(...) : arr`) is safe if downstream code (like a sorting function) creates a shallow copy before mutation.
+**Action:** Always check if a filter condition is active before executing array `.filter()` on large lists, and verify downstream mutation safety.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -931,7 +931,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const renderLocalFiles = () => {
         // ⚡ Bolt: Filter files before sorting to improve performance.
         // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list.
-        const filtered = localFilesList.filter(f => f.name.toLowerCase().includes(localFilter));
+        // ⚡ Bolt: Conditionally bypass array filtering when search string is empty.
+        // 📊 Impact: Avoids O(N) string comparisons and memory allocation for the entire list.
+        const filtered = localFilter ? localFilesList.filter(f => f.name.toLowerCase().includes(localFilter)) : localFilesList;
         const sorted = sortFiles(filtered, localSort.key, localSort.dir);
         updateSortHeaders('file-table', localSort);
         fileListBody.innerHTML = '';
@@ -1123,7 +1125,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Remote Files ---
 
     const renderRemoteFiles = () => {
-        const filtered = remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter));
+        // ⚡ Bolt: Conditionally bypass array filtering when search string is empty.
+        // 📊 Impact: Avoids O(N) string comparisons and memory allocation for the entire list.
+        const filtered = remoteFilter ? remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter)) : remoteFilesList;
         const sorted = sortFiles(filtered, remoteSort.key, remoteSort.dir);
         updateSortHeaders('remote-file-table', remoteSort);
         remoteFileListBody.innerHTML = '';


### PR DESCRIPTION
💡 What: Conditionally bypass array `.filter()` operations over large UI lists in `ui/static/app.js` when the search/filter condition is empty using a ternary operator. Added comments to document the optimization.
🎯 Why: In vanilla JS frontends, unconditionally running `.filter()` over large arrays when the filter condition is empty wastes O(N) iterations, string comparisons, and memory allocations. Returning the original array reference via a ternary operator is safe here because downstream code (`sortFiles`) correctly creates a shallow copy before mutation.
📊 Impact: Avoids unnecessary iterations, `.toLowerCase().includes()` comparisons, and object allocations matching the array length. On thousands of elements this saves rendering latency and memory.
🔬 Measurement: Verified the code behavior using frontend UI tests (Playwright) filtering local/remote mock objects and confirmed functional equivalence. Run the JS app and check CPU profiling over large lists with empty filters.

---
*PR created automatically by Jules for task [2517922544603969994](https://jules.google.com/task/2517922544603969994) started by @arumes31*