### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix log injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,7 @@
 **Vulnerability:** Unbounded in-memory map tracking rate limiters (`qm.limiters`) per host allows a malicious user or numerous unauthenticated requests with unique hosts to exhaust server memory, leading to a Denial of Service (DoS).
 **Learning:** Maps used for state tracking (e.g., rate limiting, metrics) without eviction mechanisms represent a severe memory leak vector. Bounding and evicting items safely prevents this.
 **Prevention:** Implement safe map bounds and evictions. Evict inactive entries when exceeding a threshold (e.g., 100). When full and all entries are active, forceful eviction of an arbitrary/oldest entry must be used rather than throwing errors or skipping caching to maintain rate-limiting properties and bound memory.
+## 2024-05-18 - Log Injection in JSON Logger Fallback
+**Vulnerability:** A log injection vulnerability was found in the custom JSON logger fallback where `log.Printf` was using `%s` formatting, and a JSON fallback string was manually constructed using `fmt.Sprintf`.
+**Learning:** Constructing JSON fallback messages via `fmt.Sprintf` with unescaped user inputs can result in JSON injection or log forging. Similarly, using `%s` rather than `%q` for string arguments inside logs allows injected newlines or characters to poison log files.
+**Prevention:** Always use `%q` for logging potentially untrusted string inputs, and always rely on safe standard libraries (like `encoding/json.Marshal`) to construct JSON formatted messages to ensure proper escaping of newlines, tabs, or quotes.

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -41,10 +41,15 @@ func LogWithLevel(level, msg string, extra interface{}) {
 
 	b, err := json.Marshal(entry)
 	if err != nil {
-		log.Printf("logger: failed to marshal log entry: %v (level=%s, msg=%s)", err, entry.Level, entry.Msg)
+		log.Printf("logger: failed to marshal log entry: %v (level=%q, msg=%q)", err, entry.Level, entry.Msg)
 		// Emit a safe fallback JSON string
-		fallback := fmt.Sprintf(`{"level":"%s","msg":"[marshal error] %s","time":"%s"}`, entry.Level, entry.Msg, entry.Time)
-		BroadcastLog(fallback)
+		safeEntry := LogMessage{
+			Level: entry.Level,
+			Time:  entry.Time,
+			Msg:   fmt.Sprintf("[marshal error] %s", entry.Msg),
+		}
+		fallbackB, _ := json.Marshal(safeEntry)
+		BroadcastLog(string(fallbackB))
 		return
 	}
 	log.Println(string(b))


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Log Injection / JSON Injection. `internal/logger/logger.go` passed untrusted input formats directly into `log.Printf` via `%s` and used `fmt.Sprintf` to manually concatenate strings into fallback JSON error messages. If user inputs contained quotes, newlines, or control characters, this could lead to log forging or JSON injection vulnerabilities.
🎯 **Impact:** Malicious users could inject arbitrary JSON fields into the logging output, spoofing log entries or causing automated log parsers to fail. They could also use newlines to add fake log events in plain-text stdout logs.
🔧 **Fix:** Changed `%s` to `%q` in `log.Printf` to safely escape string outputs. Updated the JSON fallback mechanism to define a new struct (`safeEntry`) containing only safe strings, which is then serialized securely via `json.Marshal` rather than string formatting.
✅ **Verification:** Verified that tests pass via `go test ./...` and confirmed the payload output correctly escapes user inputs containing newlines and quotes.

---
*PR created automatically by Jules for task [2411616421454853797](https://jules.google.com/task/2411616421454853797) started by @arumes31*