### PR TITLE
🎨 Palette: Add visual indicators for required fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2024-07-14 - Required Field Visual Indicators in Configuration Forms
+**Learning:** Found that our SFTP configuration forms relied solely on HTML5 `required` attributes, leaving visual users without clear indicators of required inputs. Adding an inline visual element like `<span style="color: var(--error);" aria-hidden="true">*</span>` explicitly communicates this to visual users while `aria-hidden="true"` prevents redundant announcements for screen reader users, since the `required` attribute already conveys the state.
+**Action:** Always visually indicate required inputs in our app's configuration forms using the `var(--error)` CSS variable and `aria-hidden="true"` to balance visual clarity and screen reader accessibility.

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
💡 What: Added visual required indicators (red asterisks) to the "Host / IP Address", "Port", and "Username" fields in the SFTP configuration form.
🎯 Why: While the HTML5 `required` attribute was present, visual users had no clear indication that these fields were mandatory. This small UX enhancement clarifies the form's requirements at a glance.
📸 Before/After: Visual asterisks now appear next to the labels.
♿ Accessibility: The visual indicators (`*`) are wrapped in a `span` with `aria-hidden="true"`. This ensures that screen reader users, who already hear that the field is required from the input's `required` attribute, are not subjected to redundant "asterisk" announcements.

---
*PR created automatically by Jules for task [9815631223650762815](https://jules.google.com/task/9815631223650762815) started by @arumes31*