### PR TITLE
🎨 Palette: Add explicit visual indicators for required form fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,7 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+
+## 2024-07-15 - Visual Indicators for Required Form Fields
+**Learning:** Found that some form fields with `required` attributes lacked explicit visual indicators (like an asterisk), which can confuse visual users. Adding a visible indicator while using `aria-hidden="true"` prevents redundant announcements for screen readers since the `required` attribute already conveys that information.
+**Action:** Always complement HTML5 `required` attributes with an explicit visual indicator hidden from screen readers to aid visual users without causing duplicate auditory feedback.

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
💡 What: Added visual indicators (red asterisks) to form fields that are marked as `required`.
🎯 Why: Directly helps visual users understand which fields must be filled out before submitting the form, making the interface more intuitive.
📸 Before/After: Visual asterisks now appear next to required fields.
♿ Accessibility: The indicators are wrapped in a `<span>` with `aria-hidden="true"`, ensuring that screen readers won't redundantly read "asterisk" or "star" for a field that their software will already announce as "required" due to the HTML5 `required` attribute.

---
*PR created automatically by Jules for task [9003422381693719013](https://jules.google.com/task/9003422381693719013) started by @arumes31*