### PR TITLE
🎨 Palette: Add visual indicators to required form fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2024-07-16 - Add visual indicators to required form fields
+**Learning:** HTML5 `required` attributes should be complemented with an explicit visual indicator (like an asterisk) hidden from screen readers using `aria-hidden="true"` to aid visual users without causing redundant announcements.
+**Action:** Always add visual indicators alongside `required` attributes and hide them from screen readers using `aria-hidden="true"`.

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -296,17 +296,17 @@
                                 <form id="sftp-form">
                                     <div class="config-grid-main">
                                         <div class="form-field span-2">
-                                            <label for="host">Host / IP Address</label>
+                                            <label for="host">Host / IP Address <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="host" name="host" placeholder="192.168.1.100"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="port">Port</label>
+                                            <label for="port">Port <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="number" id="port" name="port" value="22" placeholder="22"
                                                 required>
                                         </div>
                                         <div class="form-field">
-                                            <label for="user">Username</label>
+                                            <label for="user">Username <span style="color: var(--error);" aria-hidden="true">*</span></label>
                                             <input type="text" id="user" name="user" placeholder="root" required>
                                         </div>
                                         <div class="form-field">


### PR DESCRIPTION
💡 **What:** Added a visual asterisk (`*`) to the `<label>` elements of the explicitly `required` form fields (Host, Port, Username) in the SFTP connection form. The asterisks are styled with the existing `var(--error)` color for consistency.
🎯 **Why:** HTML5 `required` attributes enforce field validation but don't inherently provide a visual cue until the form is submitted. Adding an explicit indicator aids visual users in instantly recognizing mandatory fields before interaction.
📸 **Before/After:** Before, the required fields lacked any visual distinction in their labels. After, they display a clear red asterisk.
♿ **Accessibility:** The added asterisks use `aria-hidden="true"` to prevent screen readers from announcing "asterisk" redundantly, as screen readers already announce the underlying input's `required` attribute. This maintains a clean audio experience while improving visual UX.

---
*PR created automatically by Jules for task [13292016497865847139](https://jules.google.com/task/13292016497865847139) started by @arumes31*