### PR TITLE
⚡ Bolt: bypass array filters on empty search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2026-06-04 - Pre-aggregate Task Stats Under Mutexes
 **Learning:** Running an O(T * H) nested loop under a `sync.RWMutex` to aggregate stats can cause high lock contention for frequently polled API endpoints (like `/api/stats`).
 **Action:** Pre-aggregate task data in a single O(T) pass into a map, and then iterate through the map in an O(H) pass to compute host stats. This brings the complexity down to O(T + H) and minimizes time spent under the read lock.
+
+## 2025-05-27 - Bypass array filters on empty search
+**Learning:** Array `.filter()` always allocates a new array and iterates through all elements. For large UI lists where the filter condition is often empty, this is a redundant O(N) operation.
+**Action:** Conditionally bypass `.filter()` when the search or filter condition is empty to avoid redundant iterations and memory allocations.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -931,7 +931,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const renderLocalFiles = () => {
         // ⚡ Bolt: Filter files before sorting to improve performance.
         // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list.
-        const filtered = localFilesList.filter(f => f.name.toLowerCase().includes(localFilter));
+        // ⚡ Bolt: Conditionally bypass array filter when search is empty.
+        // 📊 Impact: Saves redundant O(N) iterations and allocations.
+        const filtered = localFilter ? localFilesList.filter(f => f.name.toLowerCase().includes(localFilter)) : localFilesList;
         const sorted = sortFiles(filtered, localSort.key, localSort.dir);
         updateSortHeaders('file-table', localSort);
         fileListBody.innerHTML = '';
@@ -1123,7 +1125,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Remote Files ---
 
     const renderRemoteFiles = () => {
-        const filtered = remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter));
+        // ⚡ Bolt: Conditionally bypass array filter when search is empty.
+        // 📊 Impact: Saves redundant O(N) iterations and allocations.
+        const filtered = remoteFilter ? remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter)) : remoteFilesList;
         const sorted = sortFiles(filtered, remoteSort.key, remoteSort.dir);
         updateSortHeaders('remote-file-table', remoteSort);
         remoteFileListBody.innerHTML = '';


### PR DESCRIPTION
💡 What: Conditionally bypassed array `.filter()` calls when `localFilter` or `remoteFilter` are empty in the vanilla JS UI.
🎯 Why: `array.filter()` always allocates a new array and iterates through every single element. On an empty search (which is the default state), `.includes("")` is true for everything, meaning the app was doing O(N) operations and allocating memory just to create an identical array.
📊 Impact: Eliminates O(N) iterations and memory allocations on every directory load or file update when the user is not actively searching, which scales performance significantly for directories with thousands of files.
🔬 Measurement: Profile the render functions in the browser DevTools when loading a large directory (>1000 files). The time taken in `renderLocalFiles` is noticeably reduced when the search is empty.

---
*PR created automatically by Jules for task [10456140341256706809](https://jules.google.com/task/10456140341256706809) started by @arumes31*