### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to queue action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+## 2024-05-24 - Contextual Accessibility for Dynamic Actions
+**Learning:** Action buttons in dynamically generated table rows (like task queues) often lack context for screen readers when they use generic text like 'Pause' or 'Remove'. This causes confusion when multiple identical buttons are present.
+**Action:** When adding interactive elements to dynamic tables or lists, always dynamically inject contextual details (e.g., the row's `task.file_name`) into their `aria-label` and `title` attributes to ensure screen readers and tooltips provide adequate context.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1430,7 +1430,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (task.status === 'Pending' || task.status === 'Paused') {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
-                    controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    const actionLabel = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.textContent = actionLabel;
+                    controlBtn.title = `${actionLabel} ${task.file_name}`;
+                    controlBtn.setAttribute('aria-label', `${actionLabel} ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1441,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.title = `Retry ${task.file_name}`;
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1450,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.title = `Remove ${task.file_name}`;
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes dynamically injecting `task.file_name` into the generic task action buttons ("Resume/Pause", "Retry", "Remove") in the queue table.
🎯 **Why:** Dynamically generated action buttons in tables often appear identically labeled to screen readers (e.g., announcing "Remove, Remove, Remove" repeatedly), providing zero context about *which* file is being removed. Injecting the filename solves this ambiguity.
📸 **Before/After:** Before: `<button class="action-btn">Remove</button>`. After: `<button class="action-btn" title="Remove video_backup.mp4" aria-label="Remove video_backup.mp4">Remove</button>`.
♿ **Accessibility:** Greatly improves screen reader and keyboard accessibility, allowing users to safely determine exactly what file an action applies to without relying on visual association.

---
*PR created automatically by Jules for task [1573545901424491662](https://jules.google.com/task/1573545901424491662) started by @arumes31*