### PR TITLE
⚡ Bolt: [performance improvement] Bypass redundant array filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2026-06-04 - Pre-aggregate Task Stats Under Mutexes
 **Learning:** Running an O(T * H) nested loop under a `sync.RWMutex` to aggregate stats can cause high lock contention for frequently polled API endpoints (like `/api/stats`).
 **Action:** Pre-aggregate task data in a single O(T) pass into a map, and then iterate through the map in an O(H) pass to compute host stats. This brings the complexity down to O(T + H) and minimizes time spent under the read lock.
+
+## 2026-07-20 - Bypass redundant array filtering
+**Learning:** Running `.filter()` on large arrays when the filter string is empty still iterates over every element and creates a new array allocation, causing O(N) overhead.
+**Action:** Conditionally bypass `.filter()` operations when the search condition is empty to avoid redundant work and memory allocations. Use shallow copies where upstream mutations are possible.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -931,7 +931,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const renderLocalFiles = () => {
         // ⚡ Bolt: Filter files before sorting to improve performance.
         // 📊 Impact: O(n log n) sorting now only runs on the matching files, not the entire list.
-        const filtered = localFilesList.filter(f => f.name.toLowerCase().includes(localFilter));
+        // ⚡ Bolt: Bypass redundant array filtering when the search string is empty to avoid O(N) allocation overhead.
+        // 📊 Impact: Reduces O(N) iterations and memory allocations when rendering large file lists without an active search.
+        // Note: sortFiles inherently creates a shallow copy, safely treating this input as immutable.
+        const filtered = localFilter ? localFilesList.filter(f => f.name.toLowerCase().includes(localFilter)) : localFilesList;
         const sorted = sortFiles(filtered, localSort.key, localSort.dir);
         updateSortHeaders('file-table', localSort);
         fileListBody.innerHTML = '';
@@ -1123,7 +1126,10 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Remote Files ---
 
     const renderRemoteFiles = () => {
-        const filtered = remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter));
+        // ⚡ Bolt: Bypass redundant array filtering when the search string is empty to avoid O(N) allocation overhead.
+        // 📊 Impact: Reduces O(N) iterations and memory allocations when rendering large file lists without an active search.
+        // Note: sortFiles inherently creates a shallow copy, safely treating this input as immutable.
+        const filtered = remoteFilter ? remoteFilesList.filter(f => f.name.toLowerCase().includes(remoteFilter)) : remoteFilesList;
         const sorted = sortFiles(filtered, remoteSort.key, remoteSort.dir);
         updateSortHeaders('remote-file-table', remoteSort);
         remoteFileListBody.innerHTML = '';


### PR DESCRIPTION
💡 What: Conditionally bypassed `.filter()` operations when the search string is empty in `renderLocalFiles` and `renderRemoteFiles`.
🎯 Why: Calling `.filter()` on large file arrays when the filter is empty still iterates over every element and allocates a new array, adding O(N) overhead.
📊 Impact: Reduces O(N) iterations and memory allocations when rendering large file lists without an active search.
🔬 Measurement: Profile the frontend rendering of large directories with and without an active search filter to observe reduced execution time and memory usage.

---
*PR created automatically by Jules for task [13204869114480737009](https://jules.google.com/task/13204869114480737009) started by @arumes31*