### PR TITLE
🎨 Palette: Add contextual ARIA labels to queue actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,7 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+
+## 2024-05-24 - Contextual Aria Labels in Dynamic Tables
+**Learning:** Action buttons in dynamic lists or tables lack context for screen readers if they only say 'Pause' or 'Remove', making it difficult to know which row they affect.
+**Action:** Always inject contextual row data (e.g., filename) into the aria-label and title attributes for generic action buttons in dynamic lists.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1430,7 +1430,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (task.status === 'Pending' || task.status === 'Paused') {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
-                    controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    const actionName = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.textContent = actionName;
+                    controlBtn.title = `${actionName} ${task.file_name}`;
+                    controlBtn.setAttribute('aria-label', `${actionName} ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1441,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.title = `Retry ${task.file_name}`;
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1450,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.title = `Remove ${task.file_name}`;
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 What: Added contextual ARIA labels and tooltips to the Pause, Resume, Retry, and Remove buttons in the queue table.
🎯 Why: Screen reader users previously heard only "Pause" or "Remove" without knowing which file the action applied to. The tooltips also help sighted users understand the action context.
📸 Before/After: N/A (Internal DOM changes)
♿ Accessibility: Screen readers now announce actions contextually, e.g., 'Pause filename.ext', improving accessibility for visually impaired users.

---
*PR created automatically by Jules for task [15076007145235361805](https://jules.google.com/task/15076007145235361805) started by @arumes31*