### PR TITLE
🎨 Palette: Add contextual ARIA labels to queue table action buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,7 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+
+## 2026-06-03 - Contextual Action Buttons in Dynamic Lists
+**Learning:** Generic button text like "Retry", "Remove", or "Pause" within dynamic lists (like task queues) lacks context for screen reader users and tooltips. Users hear "Retry button" without knowing what file is being retried.
+**Action:** When adding interactive elements to dynamic tables or lists, dynamically inject contextual details (e.g., `${task.file_name}`) into their `aria-label` and `title` attributes.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1430,7 +1430,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (task.status === 'Pending' || task.status === 'Paused') {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
-                    controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    const actionName = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.textContent = actionName;
+                    controlBtn.title = `${actionName} ${task.file_name}`;
+                    controlBtn.setAttribute('aria-label', `${actionName} ${task.file_name}`);
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1441,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.title = `Retry ${task.file_name}`;
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1450,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.title = `Remove ${task.file_name}`;
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 What: 
Added dynamic context (the `task.file_name`) to the `title` and `aria-label` attributes of generic action buttons in the Task Queue table (Pause, Resume, Retry, Remove).

🎯 Why:
Generic button labels like "Retry" or "Remove" lack context, especially in dynamic lists. Users need to know exactly *what* they are retrying or removing without having to deduce it from the surrounding row context. This is particularly difficult for screen reader users navigating by interactive elements.

📸 Before/After:
*   **Before:** `<button class="action-btn">Retry</button>`
*   **After:** `<button class="action-btn" title="Retry backup.zip" aria-label="Retry backup.zip">Retry</button>`

♿ Accessibility:
Significantly improves screen reader experience. Instead of hearing "Retry button", users now hear "Retry backup.zip button", immediately providing the necessary context for the action. It also benefits sighted users by providing helpful tooltips on hover.

---
*PR created automatically by Jules for task [17133972988838841401](https://jules.google.com/task/17133972988838841401) started by @arumes31*