### PR TITLE
🎨 Palette: Add contextual ARIA labels to queue buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_data/
 /queue
 .Jules/
 .Jules
+server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,7 @@
 ## 2024-04-30 - Password Visibility Toggle
 **Learning:** Users need to verify their master password before submitting, and relying on missing/stubbed JS features (like fa-eye toggles without UI) creates a frustrating dead end.
 **Action:** Always implement a functional visibility toggle for sensitive inputs with proper ARIA labels and SVG swapping.
+
+## 2024-05-24 - Dynamic Action Button Context
+**Learning:** Generic action buttons (like "Remove" or "Retry") inside dynamic lists lack context for screen readers when they only contain the action name.
+**Action:** Always inject contextual details (e.g., the row's target file name) into the aria-label and title attributes when dynamically generating these buttons.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -1431,6 +1431,9 @@ document.addEventListener('DOMContentLoaded', () => {
                     const controlBtn = document.createElement('button');
                     controlBtn.className = 'action-btn';
                     controlBtn.textContent = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    const actionName = task.status === 'Paused' ? 'Resume' : 'Pause';
+                    controlBtn.setAttribute('aria-label', `${actionName} ${task.file_name}`);
+                    controlBtn.title = `${actionName} ${task.file_name}`;
                     controlBtn.addEventListener('click', () => controlTask(task.id, task.status === 'Paused' ? 'resume' : 'pause'));
                     tdActions.appendChild(controlBtn);
                 } else if (task.status === 'Failed' || task.status === 'Completed') {
@@ -1438,6 +1441,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const retryBtn = document.createElement('button');
                         retryBtn.className = 'action-btn';
                         retryBtn.textContent = 'Retry';
+                        retryBtn.setAttribute('aria-label', `Retry ${task.file_name}`);
+                        retryBtn.title = `Retry ${task.file_name}`;
                         retryBtn.addEventListener('click', () => controlTask(task.id, 'retry'));
                         tdActions.appendChild(retryBtn);
                     }
@@ -1445,6 +1450,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const remBtn = document.createElement('button');
                 remBtn.className = 'action-btn btn-danger-text';
                 remBtn.textContent = 'Remove';
+                remBtn.setAttribute('aria-label', `Remove ${task.file_name}`);
+                remBtn.title = `Remove ${task.file_name}`;
                 remBtn.addEventListener('click', () => controlTask(task.id, 'remove'));
                 tdActions.appendChild(remBtn);
 


### PR DESCRIPTION
💡 What: Added task file name context to the aria-label and title attributes of the Pause/Resume, Retry, and Remove buttons in the task queue table.
🎯 Why: Generic buttons like 'Remove' in dynamic tables lack context for screen reader users and can be ambiguous. Adding the file name clarifies exactly which item the action applies to.
📸 Before/After: N/A (improves tooltips and screen reader announcements).
♿ Accessibility: Ensures dynamic action buttons have descriptive, contextual names.

---
*PR created automatically by Jules for task [123285248502653929](https://jules.google.com/task/123285248502653929) started by @arumes31*