### PR TITLE
⚡ Bolt: Optimize file extension parsing in sort loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,7 @@
 ## 2026-06-04 - Pre-aggregate Task Stats Under Mutexes
 **Learning:** Running an O(T * H) nested loop under a `sync.RWMutex` to aggregate stats can cause high lock contention for frequently polled API endpoints (like `/api/stats`).
 **Action:** Pre-aggregate task data in a single O(T) pass into a map, and then iterate through the map in an O(H) pass to compute host stats. This brings the complexity down to O(T + H) and minimizes time spent under the read lock.
+
+## 2025-07-25 - Avoid split for file extensions in hot loops
+**Learning:** Using `split(.).pop()` to parse file extensions creates unnecessary intermediate arrays and causes GC pressure, especially in $O(N \log N)$ hot paths like sorting arrays.
+**Action:** Always use `lastIndexOf(.)` and `substring()` for file extension parsing in JavaScript tight loops, ensuring dotfiles are properly handled by checking `!== -1` and `!== 0`.

--- a/ui/static/app.js
+++ b/ui/static/app.js
@@ -293,9 +293,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 case 'size':
                     return dirMul * ((a.size || 0) - (b.size || 0));
                 case 'type': {
-                    const extA = a.name.includes('.') ? a.name.split('.').pop().toLowerCase() : '';
-                    const extB = b.name.includes('.') ? b.name.split('.').pop().toLowerCase() : '';
-                    return dirMul * basicCollator.compare(extA, extB);
+                    // Bolt: Optimize file extension parsing in hot loop (avoid intermediate arrays)
+                    const getExt = (name) => {
+                        const i = name.lastIndexOf('.');
+                        return (i > 0) ? name.substring(i + 1).toLowerCase() : '';
+                    };
+                    return dirMul * basicCollator.compare(getExt(a.name), getExt(b.name));
                 }
                 default:
                     return 0;


### PR DESCRIPTION
💡 What: Replaced `split('.').pop()` with `lastIndexOf` and `substring` for file extension parsing in the `sortFiles` function.
🎯 Why: The original implementation created unnecessary intermediate arrays during array sorting, leading to O(N log N) garbage collection pressure.
📊 Impact: Reduces memory allocation and speeds up frontend file sorting for large directories.
🔬 Measurement: Sort a directory with 10,000 files by 'type' and observe lower memory usage and faster sorting in the browser's performance profiler.

---
*PR created automatically by Jules for task [1432379733866478923](https://jules.google.com/task/1432379733866478923) started by @arumes31*