### PR TITLE
chore(ci): drop workflow triggers for branches that no longer exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, v2_test ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, v2_test ]
+    branches: [ main ]
 
 permissions:
   contents: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker Build & Push
 
 on:
   push:
-    branches: [ main, v2.2 ]
+    branches: [ main ]
     tags: [ 'v*.*.*' ]
 
 env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,7 +2,7 @@ name: Go Security Scan
 
 on:
   push:
-    branches: [ main, v2_test ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
   schedule:


### PR DESCRIPTION
`ci.yml` and `security.yml` fired on pushes to `v2_test`, and `docker.yml` on pushes to `v2.2`. Neither branch exists on the remote — the only remote branches are `main` and the newly created `v2.7` — so those triggers were dead config implying a build and release path the repo no longer has.

All four workflows now key off `main` only, which is what `tag.yml` already did. Pull requests are unaffected: those triggers target `main`, so PRs from any branch still run the full suite.

Note this deliberately leaves `v2.7` without push-triggered CI or image publishing. Opening a PR from it into `main` still runs everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)