### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in SFTP validateRemotePath

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,7 @@
 **Vulnerability:** None in practice, but gosec >= 2.26 reports G124 on the login cookie because `Secure` is assigned from `isSecureRequest(r)` rather than a literal `true`, which it cannot evaluate statically.
 **Learning:** A scanner upgrade can block an otherwise routine dependency bump on a false positive. The finding needs triage, not a blanket suppression of the rule.
 **Prevention:** Annotate the specific statement with `// #nosec G124` and a comment explaining why the attribute is dynamic, matching the existing annotation on the logout cookie.
+## 2025-02-28 - [CRITICAL] Fix Path Traversal in SFTP validateRemotePath
+**Vulnerability:** The `validateRemotePath` logic allowed arbitrary file access on the SFTP server by checking `!path.IsAbs(p)` and explicitly setting the security base to `/` if the user provided an absolute path, bypassing the intended `RemoteDir` jail.
+**Learning:** Trusting absolute paths from user input to determine the jailing directory defeats directory restrictions. User input must always be validated against a strict, predefined base directory.
+**Prevention:** Always use the configured base directory (e.g., `RemoteDir`) as the absolute root constraint. Convert paths to relative against the base directory safely, rejecting anything that escapes (`..` or `../`).

--- a/internal/sftpclient/client.go
+++ b/internal/sftpclient/client.go
@@ -508,17 +508,18 @@ func (s *SFTPClient) validateRemotePath(p string) (string, error) {
 	p = path.Clean(filepath.ToSlash(p))
 
 	// Determine the security base.
-	// If the path is absolute, we allow navigation anywhere in the SFTP account (base = /).
-	// If the path is relative, we jail it to the configured RemoteDir.
-	base := "/"
+	base := path.Clean(filepath.ToSlash(s.RemoteDir))
+
+	// If the path is relative, we append it to the base.
+	// If the user provides an absolute path, we must still enforce
+	// that it falls within the RemoteDir.
 	if !path.IsAbs(p) {
-		base = path.Clean(filepath.ToSlash(s.RemoteDir))
-		// Join joining the relative path with the base allows filepath.Rel
-		// to correctly detect upward traversal on all platforms.
 		p = path.Join(base, p)
 	}
 
-	rel, err := filepath.Rel(base, p)
+	// filepath.Rel expects OS-specific paths.
+	// base and p are POSIX paths. Convert them to OS paths for filepath.Rel.
+	rel, err := filepath.Rel(filepath.FromSlash(base), filepath.FromSlash(p))
 	if err != nil {
 		return "", fmt.Errorf("invalid remote path")
 	}

--- a/internal/sftpclient/client_test.go
+++ b/internal/sftpclient/client_test.go
@@ -595,13 +595,19 @@ func TestSFTPClient_ValidateRemotePath(t *testing.T) {
 		t.Errorf("Unexpected path: %s", p)
 	}
 
-	// New behavior: absolute paths are allowed anywhere starting from /
-	p2, err := client.validateRemotePath("/etc/passwd")
-	if err != nil {
-		t.Errorf("Expected success for absolute path, got %v", err)
+	// Expected behavior: absolute paths that escape RemoteDir should be rejected
+	_, err = client.validateRemotePath("/etc/passwd")
+	if err == nil || !strings.Contains(err.Error(), "traversal detected") {
+		t.Errorf("Expected traversal error for absolute path escaping RemoteDir, got %v", err)
 	}
-	if p2 != "/etc/passwd" {
-		t.Errorf("Unexpected path: %s", p2)
+
+	// Test absolute path within RemoteDir
+	p3, err := client.validateRemotePath("/upload/sub/file.txt")
+	if err != nil {
+		t.Errorf("Expected success for absolute path within RemoteDir, got %v", err)
+	}
+	if p3 != "/upload/sub/file.txt" {
+		t.Errorf("Unexpected path: %s", p3)
 	}
 
 	// Test relative escape attempt
@@ -625,14 +631,14 @@ func TestSFTPClient_FileSystemActions(t *testing.T) {
 		t.Error(err)
 	}
 
-	if err := client.Mkdir("/root"); err != nil {
-		t.Errorf("Expected success for absolute path, got %v", err)
+	if err := client.Mkdir("/root"); err == nil || !strings.Contains(err.Error(), "traversal detected") {
+		t.Errorf("Expected traversal error for absolute path escaping RemoteDir, got %v", err)
 	}
-	if err := client.Remove("/root"); err != nil {
-		t.Errorf("Expected success for absolute path, got %v", err)
+	if err := client.Remove("/root"); err == nil || !strings.Contains(err.Error(), "traversal detected") {
+		t.Errorf("Expected traversal error for absolute path escaping RemoteDir, got %v", err)
 	}
-	if err := client.Rename("/upload/a", "/root"); err != nil {
-		t.Errorf("Expected success for absolute path, got %v", err)
+	if err := client.Rename("/upload/a", "/root"); err == nil || !strings.Contains(err.Error(), "traversal detected") {
+		t.Errorf("Expected traversal error for absolute path escaping RemoteDir, got %v", err)
 	}
 }
 
@@ -652,8 +658,8 @@ func TestSFTPClient_ReadRemoteDir(t *testing.T) {
 	}
 
 	_, err = client.ReadRemoteDir("/etc")
-	if err != nil {
-		t.Errorf("Expected success for absolute path, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "traversal detected") {
+		t.Errorf("Expected traversal error for absolute path escaping RemoteDir, got %v", err)
 	}
 }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `validateRemotePath` function in `internal/sftpclient/client.go` allowed directory traversal on the remote SFTP server. By providing an absolute path (e.g., `/etc/passwd`), the check `!path.IsAbs(p)` would fail, setting the security base explicitly to `/` instead of the configured `RemoteDir`. This bypassed the directory jailing logic entirely.
🎯 Impact: A malicious authenticated user or an attacker exploiting another flaw could read or manipulate any file on the remote SFTP server, regardless of the restrictions placed via `RemoteDir`.
🔧 Fix: Removed the bypass for absolute paths. `validateRemotePath` now strictly ensures that any path evaluated (even if provided as an absolute path from the client) is resolved relative to the absolute `RemoteDir` base and does not traverse above it.
✅ Verification: `go test ./...` in the `internal/sftpclient` package passes. The `client_test.go` has been updated to explicitly expect traversal errors for absolute paths escaping the `RemoteDir`.

---
*PR created automatically by Jules for task [2011408086249101945](https://jules.google.com/task/2011408086249101945) started by @arumes31*